### PR TITLE
Don't show additional toolbar in Address screen

### DIFF
--- a/wallet/res/values/styles.xml
+++ b/wallet/res/values/styles.xml
@@ -13,6 +13,8 @@
 		<item name="android:checkboxStyle">@style/My.Widget.CompoundButton.CheckBox</item>
 		<item name="android:spinnerStyle">@style/My.Widget.Spinner</item>
 		<item name="android:windowContentOverlay">@null</item>
+		<item name="windowActionModeOverlay">true</item>
+		<item name="actionModeBackground">@drawable/toolbar_background</item>
 	</style>
 
 	<style name="My.Theme.NoStatusBar" parent="My.Theme.NoActionBar">


### PR DESCRIPTION
# Description
- An additional Toolbar is shown when an Address is Selected.

# Changes
- Added `windowActionModeOverlay` and `actionModeBackground` in the app's Theme Styles

# Evidence

### Before
<img src="https://user-images.githubusercontent.com/564039/34897984-cb664e26-f7be-11e7-8a21-cce3ad0b213f.gif" width="300" />

### After
<img src="https://user-images.githubusercontent.com/564039/34897992-d1022328-f7be-11e7-9457-f42a81d3f1fe.gif" width="300" />

