### PR TITLE
Hiding Scan QR Button on Transactions Screen when Scrolling

### DIFF
--- a/wallet/res/anim/fab_hide.xml
+++ b/wallet/res/anim/fab_hide.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/decelerate_quad"
+    android:fillAfter="true">
+    <translate
+        android:duration="@android:integer/config_longAnimTime"
+        android:fromYDelta="0%"
+        android:toYDelta="100%p" />
+</set>

--- a/wallet/res/anim/fab_show.xml
+++ b/wallet/res/anim/fab_show.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="utf-8"?>
+<set xmlns:android="http://schemas.android.com/apk/res/android"
+    android:interpolator="@android:interpolator/decelerate_quad"
+    android:fillAfter="true">
+    <translate
+        android:duration="@android:integer/config_shortAnimTime"
+        android:fromYDelta="100%p"
+        android:toYDelta="0%" />
+</set>

--- a/wallet/res/layout/wallet_activity_onepane_vertical.xml
+++ b/wallet/res/layout/wallet_activity_onepane_vertical.xml
@@ -61,6 +61,7 @@
                 android:layout_marginBottom="16dp"
                 android:layout_marginRight="16dp"
                 android:src="@drawable/ic_qrcode"
+                app:layout_behavior="de.schildbach.wallet.ui.widget.ScrollFABBehavior"
                 app:backgroundTint="@color/strong_blue_new" />
 
         </android.support.design.widget.CoordinatorLayout>

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -24,8 +24,6 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
-import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.LinkedList;
@@ -34,8 +32,6 @@ import java.util.List;
 import org.bitcoinj.core.Transaction;
 import org.bitcoinj.core.VerificationException;
 import org.bitcoinj.core.VersionedChecksummedBytes;
-import org.bitcoinj.crypto.MnemonicCode;
-import org.bitcoinj.crypto.MnemonicException;
 import org.bitcoinj.wallet.Wallet;
 import org.bitcoinj.wallet.Wallet.BalanceType;
 
@@ -54,7 +50,6 @@ import de.schildbach.wallet.ui.send.SweepWalletActivity;
 import de.schildbach.wallet.util.CrashReporter;
 import de.schildbach.wallet.util.Crypto;
 import de.schildbach.wallet.util.Io;
-import de.schildbach.wallet.util.KeyboardUtil;
 import de.schildbach.wallet.util.Nfc;
 import de.schildbach.wallet.util.WalletUtils;
 import de.schildbach.wallet_test.R;
@@ -103,7 +98,8 @@ import android.widget.TextView;
  * @author Andreas Schildbach
  */
 public final class WalletActivity extends AbstractBindServiceActivity
-        implements ActivityCompat.OnRequestPermissionsResultCallback, NavigationView.OnNavigationItemSelectedListener {
+        implements ActivityCompat.OnRequestPermissionsResultCallback, NavigationView.OnNavigationItemSelectedListener,
+        WalletTransactionsFragment.OnFilterSelected {
     private static final int DIALOG_BACKUP_WALLET_PERMISSION = 0;
     private static final int DIALOG_RESTORE_WALLET_PERMISSION = 1;
     private static final int DIALOG_RESTORE_WALLET = 2;
@@ -117,6 +113,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
     private DrawerLayout viewDrawer;
     private View viewFakeForSafetySubmenu;
+    private FloatingActionButton fabScanQr;
 
     private Handler handler = new Handler();
 
@@ -201,7 +198,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
     }
 
     private void initFloatingButton() {
-        FloatingActionButton fabScanQr = (FloatingActionButton) findViewById(R.id.fab_scan_qr);
+        fabScanQr = (FloatingActionButton) findViewById(R.id.fab_scan_qr);
         fabScanQr.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View view) {
@@ -1020,5 +1017,12 @@ public final class WalletActivity extends AbstractBindServiceActivity
     private void handleDisconnect() {
         getWalletApplication().stopBlockchainService();
         finish();
+    }
+
+    //Reset FAB State when filter is selected
+    @Override
+    public void onFilterSelected() {
+        fabScanQr.clearAnimation();
+        fabScanQr.setClickable(true);
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
@@ -280,6 +280,10 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
         args.putSerializable(ARG_DIRECTION, direction);
         loaderManager.restartLoader(ID_TRANSACTION_LOADER, args, this);
 
+        if (getActivity() instanceof OnFilterSelected) {
+            ((OnFilterSelected) getActivity()).onFilterSelected();
+        }
+
         return true;
     }
 
@@ -603,5 +607,9 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
             return Warning.STORAGE_ENCRYPTION;
         else
             return null;
+    }
+
+    interface OnFilterSelected {
+        void onFilterSelected();
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/widget/ScrollFABBehavior.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/ScrollFABBehavior.java
@@ -1,0 +1,82 @@
+package de.schildbach.wallet.ui.widget;
+
+import android.content.Context;
+import android.support.design.widget.CoordinatorLayout;
+import android.support.design.widget.FloatingActionButton;
+import android.support.v4.view.ViewCompat;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.animation.Animation;
+import android.view.animation.AnimationUtils;
+
+import de.schildbach.wallet_test.R;
+
+/**
+ * @author Samuel Barbosa
+ */
+public class ScrollFABBehavior extends FloatingActionButton.Behavior {
+
+    private Animation showFabAnimation;
+    private Animation hideFabAnimation;
+    private Animation currentAnimation;
+    private boolean isShown = true;
+    private FloatingActionButton fab;
+
+    public ScrollFABBehavior(Context context, AttributeSet attrs) {
+        super();
+
+        showFabAnimation = AnimationUtils.loadAnimation(context, R.anim.fab_show);
+        hideFabAnimation = AnimationUtils.loadAnimation(context, R.anim.fab_hide);
+
+        Animation.AnimationListener fabAnimationListener = new Animation.AnimationListener() {
+            @Override
+            public void onAnimationStart(Animation animation) {
+                currentAnimation = animation;
+            }
+
+            @Override
+            public void onAnimationEnd(Animation animation) {
+                isShown = animation == showFabAnimation;
+                fab.setClickable(isShown);
+            }
+
+            @Override
+            public void onAnimationRepeat(Animation animation) {
+
+            }
+        };
+
+        showFabAnimation.setAnimationListener(fabAnimationListener);
+        hideFabAnimation.setAnimationListener(fabAnimationListener);
+    }
+
+    @Override
+    public boolean onStartNestedScroll(CoordinatorLayout coordinatorLayout,
+                                       FloatingActionButton child, View directTargetChild,
+                                       View target, int nestedScrollAxes) {
+        fab = child;
+        return nestedScrollAxes == ViewCompat.SCROLL_AXIS_VERTICAL ||
+                super.onStartNestedScroll(coordinatorLayout, child, directTargetChild, target,
+                        nestedScrollAxes);
+    }
+
+    @Override
+    public void onNestedScroll(CoordinatorLayout coordinatorLayout, FloatingActionButton child,
+                               View target, int dxConsumed, int dyConsumed, int dxUnconsumed,
+                               int dyUnconsumed) {
+        super.onNestedScroll(coordinatorLayout, child, target, dxConsumed, dyConsumed, dxUnconsumed,
+                dyUnconsumed);
+        //Cancel current animation
+        if (currentAnimation != null &&
+                currentAnimation.hasStarted() && !currentAnimation.hasEnded()) {
+            currentAnimation.cancel();
+        }
+        //Start hide or show fab animation according to scrolling position
+        if (dyConsumed > 0 && isShown) {
+            child.startAnimation(hideFabAnimation); //scroll down -> hide
+        } else if (dyConsumed < 0 && !isShown) {
+            child.startAnimation(showFabAnimation); //scroll ul -> show
+        }
+    }
+
+}


### PR DESCRIPTION
# Description
- The Scan QR button hides part of the transaction data on the main screen

# Changes
- Created `ScrollFABBehavior` class and set as layout behavior in the Scan QR Button on the main screen layout, this layout behavior will hide the button when scrolling down the list and show it again when scrolling up.
- Created `WalletTransactionsFragment.OnFilterSelected` interface, implementing it in `Wallet Activity` and calling it form `WalletTransactionsFragment` when a filter is selected to restore the visual state of the Scan QR Button.

# Evidence

### Before
<img src="https://user-images.githubusercontent.com/564039/34971819-3d9040d6-fa4b-11e7-9411-025570d8923c.gif" width="300" />

### After
<img src="https://user-images.githubusercontent.com/564039/34971926-04ddbd8a-fa4c-11e7-8b36-c07dd40cd5dc.gif" width="300" />
