### PR TITLE
Hiding Scan button on Send Coins Screen when Soft Keyboard goes up

### DIFF
--- a/wallet/res/layout/send_coins_content.xml
+++ b/wallet/res/layout/send_coins_content.xml
@@ -1,4 +1,5 @@
-<de.schildbach.wallet.ui.widget.KeyboardResponsiveCoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<de.schildbach.wallet.ui.widget.KeyboardResponsiveCoordinatorLayout
+    xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
     app:viewToHideWhenSoftKeyboardIsOpen="@+id/fab_scan_qr"

--- a/wallet/res/layout/send_coins_content.xml
+++ b/wallet/res/layout/send_coins_content.xml
@@ -1,6 +1,7 @@
-<android.support.design.widget.CoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
+<de.schildbach.wallet.ui.widget.KeyboardResponsiveCoordinatorLayout xmlns:android="http://schemas.android.com/apk/res/android"
     xmlns:app="http://schemas.android.com/apk/res-auto"
     xmlns:tools="http://schemas.android.com/tools"
+    app:viewToHideWhenSoftKeyboardIsOpen="@+id/fab_scan_qr"
     android:layout_width="match_parent"
     android:layout_height="match_parent"
     android:orientation="vertical">
@@ -30,10 +31,11 @@
                 tools:layout="@layout/address_book_row" />
 
         </ScrollView>
+
     </LinearLayout>
 
     <android.support.design.widget.FloatingActionButton
-        android:id="@+id/fab_scan_qr"
+        android:id="@id/fab_scan_qr"
         android:layout_width="wrap_content"
         android:layout_height="wrap_content"
         android:layout_gravity="bottom|end"
@@ -42,4 +44,4 @@
         android:src="@drawable/ic_qrcode"
         app:backgroundTint="@color/strong_blue_new" />
 
-</android.support.design.widget.CoordinatorLayout>
+</de.schildbach.wallet.ui.widget.KeyboardResponsiveCoordinatorLayout>

--- a/wallet/res/layout/send_coins_fragment.xml
+++ b/wallet/res/layout/send_coins_fragment.xml
@@ -5,7 +5,8 @@
 	tools:ignore="RequiredSize"
 	android:layout_width="match_parent"
 	android:layout_height="match_parent"
-	android:paddingTop="16dp">
+	android:paddingTop="16dp"
+	android:focusableInTouchMode="true">
 
 	<LinearLayout
 		android:id="@+id/send_coins_payee_group"

--- a/wallet/res/menu/send_coins_fragment_options.xml
+++ b/wallet/res/menu/send_coins_fragment_options.xml
@@ -1,11 +1,5 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android" >
-
-    <item
-        android:id="@+id/send_coins_options_scan"
-        android:icon="@drawable/ic_photo_camera_white_24dp"
-        android:showAsAction="always|withText"
-        android:title="@string/button_scan"/>
     <item
         android:id="@+id/send_coins_options_fee_category"
         android:showAsAction="never"
@@ -31,5 +25,4 @@
         android:id="@+id/send_coins_options_empty"
         android:showAsAction="never"
         android:title="@string/send_coins_options_empty"/>
-
 </menu>

--- a/wallet/res/values/attrs.xml
+++ b/wallet/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="KeyboardResponsiveCoordinatorLayout">
+        <attr name="viewToHideWhenSoftKeyboardIsOpen" format="reference" />
+    </declare-styleable>
+</resources>

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -134,6 +134,7 @@ import android.view.View;
 import android.view.View.OnClickListener;
 import android.view.View.OnFocusChangeListener;
 import android.view.ViewGroup;
+import android.view.WindowManager;
 import android.widget.AdapterView;
 import android.widget.AutoCompleteTextView;
 import android.widget.Button;
@@ -144,7 +145,6 @@ import android.widget.CursorAdapter;
 import android.widget.EditText;
 import android.widget.FrameLayout;
 import android.widget.TextView;
-import de.schildbach.wallet_test.R;
 import android.app.LoaderManager.LoaderCallbacks;
 
 /**
@@ -591,8 +591,7 @@ public final class SendCoinsFragment extends Fragment {
         initFloatingButton();
     }
 
-    private void initFloatingButton()
-    {
+    private void initFloatingButton() {
         viewFabScanQr = (FloatingActionButton) this.activity.findViewById(R.id.fab_scan_qr);
         final PackageManager pm = this.activity.getPackageManager();
         boolean hasCamera = pm.hasSystemFeature(PackageManager.FEATURE_CAMERA) || pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT);
@@ -735,10 +734,9 @@ public final class SendCoinsFragment extends Fragment {
             public void onClick(final View v) {
                 validateReceivingAddress();
 
-                if (everythingPlausible())
+                if (everythingPlausible()) {
                     handleGo();
-                else
-                    requestFocusFirst();
+                }
 
                 updateView();
             }
@@ -904,12 +902,6 @@ public final class SendCoinsFragment extends Fragment {
 
     @Override
     public void onPrepareOptionsMenu(final Menu menu) {
-        //final MenuItem scanAction = menu.findItem(R.id.send_coins_options_scan);
-        //final PackageManager pm = activity.getPackageManager();
-        //scanAction.setVisible(pm.hasSystemFeature(PackageManager.FEATURE_CAMERA)
-        //		|| pm.hasSystemFeature(PackageManager.FEATURE_CAMERA_FRONT));
-        //scanAction.setEnabled(state == State.INPUT);
-
         final MenuItem emptyAction = menu.findItem(R.id.send_coins_options_empty);
         emptyAction.setEnabled(state == State.INPUT && paymentIntent.mayEditAmount());
 
@@ -1005,10 +997,11 @@ public final class SendCoinsFragment extends Fragment {
 
     private void requestFocusFirst() {
         if (!isPayeePlausible())
-            receivingAddressView.requestFocus();
-        else if (!isAmountPlausible())
+            return;
+        else if (!isAmountPlausible()) {
             amountCalculatorLink.requestFocus();
-        else if (!isPasswordPlausible())
+            getActivity().getWindow().setSoftInputMode(WindowManager.LayoutParams.SOFT_INPUT_STATE_UNCHANGED);
+        } else if (!isPasswordPlausible())
             privateKeyPasswordView.requestFocus();
         else if (everythingPlausible())
             viewGo.requestFocus();

--- a/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
@@ -1,0 +1,94 @@
+package de.schildbach.wallet.ui.widget;
+
+import android.content.Context;
+import android.content.res.TypedArray;
+import android.graphics.Rect;
+import android.support.annotation.Nullable;
+import android.support.design.widget.CoordinatorLayout;
+import android.util.AttributeSet;
+import android.view.View;
+import android.view.ViewTreeObserver;
+
+import de.schildbach.wallet_test.R;
+
+/**
+ * @author Samuel Barbosa
+ */
+public class KeyboardResponsiveCoordinatorLayout extends CoordinatorLayout {
+
+    private final Rect rect;
+    private View decorView;
+
+    private final int idOfViewToHide;
+    private @Nullable View viewToHide;
+
+    public KeyboardResponsiveCoordinatorLayout(Context context) {
+        this(context, null);
+    }
+
+    public KeyboardResponsiveCoordinatorLayout(Context context, AttributeSet attrs) {
+        this(context, attrs, 0);
+    }
+
+    public KeyboardResponsiveCoordinatorLayout(Context context, AttributeSet attrs, int defStyleAttr) {
+        super(context, attrs, defStyleAttr);
+
+        rect = new Rect();
+
+        final TypedArray styleAttributeArray = getContext().getTheme().obtainStyledAttributes(
+                attrs, R.styleable.KeyboardResponsiveCoordinatorLayout, 0, 0);
+
+        try {
+            idOfViewToHide = styleAttributeArray.getResourceId(R.styleable.KeyboardResponsiveCoordinatorLayout_viewToHideWhenSoftKeyboardIsOpen, -1);
+        } finally {
+            styleAttributeArray.recycle();
+        }
+    }
+
+    private ViewTreeObserver.OnGlobalLayoutListener layoutListener = new ViewTreeObserver.OnGlobalLayoutListener() {
+        @Override
+        public void onGlobalLayout() {
+            int difference = calculateDifferenceBetweenHeightAndUsableArea();
+
+            if (difference != 0) {
+                if (viewToHide != null) {
+                    viewToHide.setVisibility(View.GONE);
+                }
+            } else {
+                if (viewToHide != null) {
+                    viewToHide.setVisibility(View.VISIBLE);
+                }
+            }
+        }
+    };
+
+    private int calculateDifferenceBetweenHeightAndUsableArea() {
+        if (decorView == null) {
+            decorView = getRootView();
+        }
+
+        decorView.getWindowVisibleDisplayFrame(rect);
+
+        return getResources().getDisplayMetrics().heightPixels - rect.bottom;
+    }
+
+    @Override
+    public void onAttachedToWindow() {
+        super.onAttachedToWindow();
+
+        getViewTreeObserver().addOnGlobalLayoutListener(layoutListener);
+
+        if (idOfViewToHide != -1) {
+            viewToHide = findViewById(idOfViewToHide);
+        }
+    }
+
+    @Override
+    public void onDetachedFromWindow() {
+        super.onDetachedFromWindow();
+
+        getViewTreeObserver().removeOnGlobalLayoutListener(layoutListener);
+
+        viewToHide = null;
+    }
+}

--- a/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
@@ -1,3 +1,20 @@
+/*
+ * Copyright 2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
 package de.schildbach.wallet.ui.widget;
 
 import android.content.Context;

--- a/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
@@ -73,7 +73,14 @@ public class KeyboardResponsiveCoordinatorLayout extends CoordinatorLayout {
                 }
             } else {
                 if (viewToHide != null) {
-                    viewToHide.setVisibility(View.VISIBLE);
+                    /*The delay is to avoid showing the scan button while the keyboard hide
+                    animation is running, which causes a visual glitch.*/
+                    viewToHide.getHandler().postDelayed(new Runnable() {
+                        @Override
+                        public void run() {
+                            viewToHide.setVisibility(View.VISIBLE);
+                        }
+                    }, 100);
                 }
             }
         }


### PR DESCRIPTION
# Description
- The `Scan QR Code Button` is hiding the `Send Button` on the `Send Coins Activity`.

# Changes
- Created a subclass of `CoordinatorLayout` named `KeyboardResponsiveCoordinatorLayout` that hides a view when the soft keyboard is opened.
- Created an optional custom attribute called `viewToHideWhenSoftKeyboardIsOpen` that can be passed to a `KeyboardResponsiveCoordinatorLayout`. The view which id is set on this attribute will be hidden if the soft keyboard shows up.

# Evidence

### Before
<img src="https://user-images.githubusercontent.com/564039/35024688-e7ec7f04-fb0e-11e7-85d9-ea12b22b091b.gif" width="300" />

### After
<img src="https://user-images.githubusercontent.com/564039/35360948-6de07038-012d-11e8-8fae-380b753ee0b1.gif" width="300" />
<img src="https://user-images.githubusercontent.com/564039/35360949-6e033370-012d-11e8-960d-3d437381b78a.gif" width="300" />

