### PR TITLE
Opening Exchange Rates from balance on Toolbar

### DIFF
--- a/wallet/androidTest/de/schildbach/wallet/ui/WalletActivityTest.java
+++ b/wallet/androidTest/de/schildbach/wallet/ui/WalletActivityTest.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2013-2015 the original author or authors.
+ *
+ * This program is free software: you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation, either version 3 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package de.schildbach.wallet.ui;
+
+import android.support.test.espresso.intent.rule.IntentsTestRule;
+import android.support.test.runner.AndroidJUnit4;
+
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+
+import de.schildbach.wallet_test.R;
+
+import static android.support.test.espresso.Espresso.onView;
+import static android.support.test.espresso.action.ViewActions.click;
+import static android.support.test.espresso.intent.Intents.intended;
+import static android.support.test.espresso.intent.matcher.IntentMatchers.hasComponent;
+import static android.support.test.espresso.matcher.ViewMatchers.withId;
+
+@RunWith(AndroidJUnit4.class)
+public class WalletActivityTest {
+
+    @Rule
+    public IntentsTestRule<WalletActivity> activityRule = new IntentsTestRule<>(WalletActivity.class);
+
+    @Test
+    public void clickOnBalanceOpenExchangeRates() {
+        onView(withId(R.id.wallet_balance)).perform(click());
+        intended(hasComponent(ExchangeRatesActivity.class.getName()));
+    }
+
+}

--- a/wallet/src/de/schildbach/wallet/ui/WalletBalanceToolbarFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletBalanceToolbarFragment.java
@@ -19,6 +19,7 @@ package de.schildbach.wallet.ui;
 
 import android.app.Activity;
 import android.content.Context;
+import android.content.Intent;
 import android.database.Cursor;
 import android.os.Bundle;
 import android.app.Fragment;
@@ -141,6 +142,14 @@ public final class WalletBalanceToolbarFragment extends Fragment
 		viewBalanceLocal = (CurrencyTextView) view.findViewById(R.id.wallet_balance_local);
 		viewBalanceLocal.setInsignificantRelativeSize(1);
 		viewBalanceLocal.setStrikeThru(Constants.TEST);
+
+		viewBalance.setOnClickListener(new OnClickListener() {
+			@Override
+			public void onClick(View v) {
+				showWarningIfBalanceTooMuch();
+				showExchangeRatesActivity();
+			}
+		});
 	}
 
     @Override
@@ -300,20 +309,21 @@ public final class WalletBalanceToolbarFragment extends Fragment
         if (balance == null)
             return;
 
-        final boolean tooMuch = balance.isGreaterThan(TOO_MUCH_BALANCE_THRESHOLD);
+        boolean tooMuch = balance.isGreaterThan(TOO_MUCH_BALANCE_THRESHOLD);
         viewBalanceTooMuch.setVisibility(tooMuch ? View.VISIBLE : View.GONE);
-        if (tooMuch)
-        {
-            viewBalance.setOnClickListener(new OnClickListener()
-            {
-                @Override
-                public void onClick(View v)
-                {
-                    Toast.makeText(application, getString(R.string.wallet_balance_fragment_too_much), Toast.LENGTH_LONG).show();
-                }
-            });
-        }
     }
+
+    private void showWarningIfBalanceTooMuch() {
+		if (balance != null && balance.isGreaterThan(TOO_MUCH_BALANCE_THRESHOLD)) {
+			Toast.makeText(application, getString(R.string.wallet_balance_fragment_too_much),
+					Toast.LENGTH_LONG).show();
+		}
+	}
+
+	private void showExchangeRatesActivity() {
+		Intent intent = new Intent(getActivity(), ExchangeRatesActivity.class);
+		getActivity().startActivity(intent);
+	}
 
 	private final LoaderManager.LoaderCallbacks<BlockchainState> blockchainStateLoaderCallbacks = new LoaderManager.LoaderCallbacks<BlockchainState>()
 	{


### PR DESCRIPTION
# Description
- Issue #62. Tapping the balance on the toolbar should show the exchange rates

# Changes
- Added `WalletActivityTest` Espresso test class.
- Launching `ExchangeRatesActivity` when clicking on balance on the toolbar.

# Evidence

### Before
<img src="https://user-images.githubusercontent.com/564039/35869875-35ed12b6-0b2e-11e8-8ab7-8c811c2a2694.gif" width="500" />

### After
<img src="https://user-images.githubusercontent.com/564039/35869885-39d524cc-0b2e-11e8-9db1-eeff3f1e3d69.gif" width="500" />
