### PR TITLE
Improve security of handling `dashwallet://` uris

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -188,7 +188,7 @@
         <activity
             android:name="de.schildbach.wallet.ui.WalletUriHandlerActivity"
             android:label="@string/app_name"
-            android:theme="@style/My.Theme.ChildActivity" >
+            android:theme="@style/My.Theme.Transparent" >
 
             <intent-filter>
                 <action android:name="android.intent.action.VIEW" />

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -32,6 +32,7 @@
 	<string name="send_coins_options_fee_category_zero">No Fee</string>
 	<string name="send_coins_fragment_hint_fee_zero">No fee of will be paid. Use \'no fee\' only if you don\'t care about confirmation time.</string>
 
-
+	<string name="wallet_uri_handler_public_key_request_dialog_msg">Application %s would like to receive your Master Public Key.  This can be used to keep track of your wallet, this can not be used to move your Dash.</string>
+	<string name="wallet_uri_handler_address_request_dialog_msg">Application %s is requesting an address so it can pay you.  Would you like to authorize this?</string>
 
 </resources>

--- a/wallet/res/values/styles.xml
+++ b/wallet/res/values/styles.xml
@@ -21,6 +21,15 @@
 
 	</style>
 
+	<style name="My.Theme.Transparent" parent="android:Theme">
+		<item name="android:windowIsTranslucent">true</item>
+		<item name="android:windowBackground">@android:color/transparent</item>
+		<item name="android:windowContentOverlay">@null</item>
+		<item name="android:windowNoTitle">true</item>
+		<item name="android:windowIsFloating">true</item>
+		<item name="android:backgroundDimEnabled">false</item>
+	</style>
+
     <style name="NewDialogTheme" parent="Theme.AppCompat.Light.Dialog.Alert">
         <item name="colorAccent">@color/strong_blue_bis</item>
         <item name="android:textColorPrimary">@color/fg_significant</item>

--- a/wallet/src/de/schildbach/wallet/ui/InputParser.java
+++ b/wallet/src/de/schildbach/wallet/ui/InputParser.java
@@ -80,7 +80,7 @@ public abstract class InputParser {
 
         @Override
         public void parse() {
-            if (input.startsWith(CoinDefinition.coinURIScheme.toUpperCase()+ ":-")) {
+            if (input.startsWith(CoinDefinition.coinURIScheme.toUpperCase() + ":-")) {
                 try {
                     final byte[] serializedPaymentRequest = Qr.decodeBinary(input.substring(9));
 
@@ -98,7 +98,7 @@ public abstract class InputParser {
 
                     error(R.string.input_parser_invalid_paymentrequest, x.getMessage());
                 }
-            } else if (input.startsWith(CoinDefinition.coinURIScheme +":")) {
+            } else if (input.startsWith(CoinDefinition.coinURIScheme + ":")) {
                 try {
                     final BitcoinURI bitcoinUri = new BitcoinURI(null, input);
                     final Address address = bitcoinUri.getAddress();
@@ -291,7 +291,7 @@ public abstract class InputParser {
             }
 
             if (walletUri.isPaymentUri()) {
-                BitcoinURI bitcoinUri = null;
+                BitcoinURI bitcoinUri;
                 try {
                     bitcoinUri = walletUri.toBitcoinUri();
                     handlePaymentIntent(PaymentIntent.fromBitcoinUri(bitcoinUri), walletUri.forceInstantSend());
@@ -301,16 +301,16 @@ public abstract class InputParser {
                     error(R.string.input_parser_invalid_bitcoin_uri, input);
                 }
             } else if (walletUri.isMasterPublicKeyRequest()) {
-                handleMasterPublicKeyRequest();
+                handleMasterPublicKeyRequest(walletUri.getSender());
             } else if (walletUri.isAddressRequest()) {
-                handleAddressRequest();
+                handleAddressRequest(walletUri.getSender());
             } else {
                 cannotClassify(input.toString());
             }
         }
 
-        protected abstract void handleMasterPublicKeyRequest();
-        protected abstract void handleAddressRequest();
+        protected abstract void handleMasterPublicKeyRequest(String sender);
+        protected abstract void handleAddressRequest(String sender);
 
         @Override
         protected void handleDirectTransaction(final Transaction transaction) throws VerificationException {


### PR DESCRIPTION
1. Added prompt in Dash Wallet when another app requests the master public key or an address using `dashwallet://...` uri.
2. Used wallet.freshReceiveAddress() instead of wallet.currentReceiveAddress() for address requests.
#77 