### PR TITLE
Removing delay when showing QR button in SendCoins screen

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/KeyboardResponsiveCoordinatorLayout.java
@@ -67,20 +67,11 @@ public class KeyboardResponsiveCoordinatorLayout extends CoordinatorLayout {
         public void onGlobalLayout() {
             int difference = calculateDifferenceBetweenHeightAndUsableArea();
 
-            if (difference != 0) {
-                if (viewToHide != null) {
+            if (viewToHide != null) {
+                if (difference != 0) {
                     viewToHide.setVisibility(View.GONE);
-                }
-            } else {
-                if (viewToHide != null) {
-                    /*The delay is to avoid showing the scan button while the keyboard hide
-                    animation is running, which causes a visual glitch.*/
-                    viewToHide.getHandler().postDelayed(new Runnable() {
-                        @Override
-                        public void run() {
-                            viewToHide.setVisibility(View.VISIBLE);
-                        }
-                    }, 100);
+                } else {
+                    viewToHide.setVisibility(View.VISIBLE);
                 }
             }
         }


### PR DESCRIPTION
# Description - Fix for #85. 
- The app is crashing with a NPE when calling `viewToHide.setVisibility(View.VISIBLE)`, there is a 100ms delay when showing the QR button and this is the most probable cause of the issue. 
- Removing the delay causes an almost not noticeable flick of the button when it's being shown in the same time that the keyboard is being shown, however, to fix the crash is more important now while we can search for an alternative (non-trivial) in the future to have it not to flick without the possibility of a crash.