### PR TITLE
Checking if DialogFragment is attached to activity.

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/EncryptKeysDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/EncryptKeysDialogFragment.java
@@ -340,7 +340,7 @@ public class EncryptKeysDialogFragment extends DialogFragment {
     }
 
     private void updateView() {
-        if (dialog == null)
+        if (dialog == null || getActivity() == null || !isAdded())
             return;
 
         final boolean hasOldPassword = !oldPasswordView.getText().toString().trim().isEmpty();


### PR DESCRIPTION
- This should address #104 by preventing updating the view when the dialog is not attached to the activity anymore.