### PR TITLE
View Recovery Phrase Enhancements

### DIFF
--- a/wallet/res/layout/backup_wallet_to_seed_dialog.xml
+++ b/wallet/res/layout/backup_wallet_to_seed_dialog.xml
@@ -138,6 +138,12 @@
                 android:textColor="@color/fg_less_significant"
                 android:textSize="@dimen/font_size_small" />
 
+            <CheckBox
+                android:id="@+id/backup_wallet_seed_private_key_written_down"
+                android:layout_width="match_parent"
+                android:layout_height="wrap_content"
+                android:text="@string/backup_wallet_seed_private_key_written_down_box" />
+
             <!--TextView
                 android:id="@+id/backup_wallet_dialog_warning_encrypted"
                 android:layout_width="match_parent"

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -67,6 +67,7 @@
 	<string name="encrypt_new_key_chain_dialog_message">Your wallet will be upgraded to support importing from and exporting to more apps.</string>
 	<string name="encrypt_new_key_chain_enter_pin_dialog_message">You must enter your PIN to finish the upgrade process.</string>
 	<string name="pin_code_required_dialog_message">This app now requires a PIN to spend and view the balance and transactions.</string>
+    <string name="backup_wallet_seed_private_key_written_down_box">I have written down the recovery phrase</string>
 
 
 </resources>

--- a/wallet/src/de/schildbach/wallet/Configuration.java
+++ b/wallet/src/de/schildbach/wallet/Configuration.java
@@ -68,6 +68,8 @@ public class Configuration {
     private static final String PREFS_KEY_CHANGE_LOG_VERSION = "change_log_version";
     public static final String PREFS_KEY_REMIND_BACKUP = "remind_backup";
     private static final String PREFS_KEY_LAST_BACKUP = "last_backup";
+    public static final String PREFS_KEY_REMIND_BACKUP_SEED = "remind_backup_seed";
+    private static final String PREFS_KEY_LAST_BACKUP_SEED = "last_backup_seed";
     public static final String PREFS_KEY_INSTANTX_ENABLED = "labs_instantx_enabled";
     public static final String PREFS_KEY_LITE_MODE = "labs_lite_mode";
 
@@ -165,7 +167,9 @@ public class Configuration {
     public boolean remindBackup() {
         return prefs.getBoolean(PREFS_KEY_REMIND_BACKUP, true);
     }
-
+    public boolean remindBackupSeed() {
+        return prefs.getBoolean(PREFS_KEY_REMIND_BACKUP_SEED, true);
+    }
     public long getLastBackupTime() {
         return prefs.getLong(PREFS_KEY_LAST_BACKUP, 0);
     }
@@ -177,6 +181,19 @@ public class Configuration {
     public void disarmBackupReminder() {
         prefs.edit().putBoolean(PREFS_KEY_REMIND_BACKUP, false)
                 .putLong(PREFS_KEY_LAST_BACKUP, System.currentTimeMillis()).apply();
+    }
+
+    public long getLastBackupSeedTime() {
+        return prefs.getLong(PREFS_KEY_LAST_BACKUP_SEED, 0);
+    }
+
+    public void armBackupSeedReminder() {
+        prefs.edit().putBoolean(PREFS_KEY_REMIND_BACKUP_SEED, true).apply();
+    }
+
+    public void disarmBackupSeedReminder() {
+        prefs.edit().putBoolean(PREFS_KEY_REMIND_BACKUP_SEED, false)
+                .putLong(PREFS_KEY_LAST_BACKUP_SEED, System.currentTimeMillis()).apply();
     }
 
     public boolean getDisclaimerEnabled() {

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
@@ -225,7 +225,12 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
                 EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
                     @Override
                     public void onDismiss(DialogInterface dialog) {
-                        onUpgradeConfirmed();
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
+                            @Override
+                            public void onDismiss(DialogInterface dialog) {
+                                onUpgradeConfirmed();
+                            }
+                        });
                     }
                 }, path);
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
@@ -65,7 +65,7 @@ import android.widget.TextView;
  */
 public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewHolder> {
     public enum Warning {
-        BACKUP, STORAGE_ENCRYPTION
+        BACKUP, BACKUP_SEED, STORAGE_ENCRYPTION
     }
 
     private final Context context;
@@ -280,7 +280,7 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
         } else if (holder instanceof WarningViewHolder) {
             final WarningViewHolder warningHolder = (WarningViewHolder) holder;
 
-            if (warning == Warning.BACKUP) {
+            if (warning == Warning.BACKUP || warning == Warning.BACKUP_SEED) {
                 if (transactions.size() == 1) {
                     warningHolder.messageView.setCompoundDrawablesWithIntrinsicBounds(0, 0, 0, 0);
                     warningHolder.messageView

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -935,7 +935,10 @@ public final class WalletActivity extends AbstractBindServiceActivity
         try {
             is = new FileInputStream(file);
             restoreWallet(WalletUtils.restorePrivateKeysFromBase58(is, Constants.NETWORK_PARAMETERS));
-
+            //remind user to backup since the key backup file does not have an HD seed
+            //Each time the user restores this backup file a new HD seed will be generated
+            config.armBackupReminder();
+            config.armBackupSeedReminder();
             log.info("successfully restored unencrypted private keys: {}", file);
         } catch (final IOException x) {
             final DialogBuilder dialog = DialogBuilder.warn(this, R.string.import_export_keys_dialog_failure_title);
@@ -1089,9 +1092,13 @@ public final class WalletActivity extends AbstractBindServiceActivity
                 EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
                     @Override
                     public void onDismiss(DialogInterface dialog) {
-                        if(isRestoringBackup) {
-                            resetBlockchain();
-                        }
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
+                            @Override
+                            public void onDismiss(DialogInterface dialog) {
+                                if(isRestoringBackup)
+                                    resetBlockchain();
+                            }
+                        });
                     }
                 }, path);
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletTransactionsFragment.java
@@ -426,6 +426,10 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
             ((WalletActivity) activity).handleBackupWallet();
             break;
 
+        case BACKUP_SEED:
+            ((WalletActivity) activity).handleBackupWalletToSeed();
+            break;
+
         case STORAGE_ENCRYPTION:
             startActivity(new Intent(Settings.ACTION_SECURITY_SETTINGS));
             break;
@@ -612,7 +616,8 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
     }
     @Override
     public void onSharedPreferenceChanged(final SharedPreferences sharedPreferences, final String key) {
-        if (Configuration.PREFS_KEY_BTC_PRECISION.equals(key) || Configuration.PREFS_KEY_REMIND_BACKUP.equals(key))
+        if (Configuration.PREFS_KEY_BTC_PRECISION.equals(key) || Configuration.PREFS_KEY_REMIND_BACKUP.equals(key) ||
+                Configuration.PREFS_KEY_REMIND_BACKUP_SEED.equals(key))
             updateView();
     }
 
@@ -623,6 +628,8 @@ public class WalletTransactionsFragment extends Fragment implements LoaderCallba
 
     private Warning warning() {
         final int storageEncryptionStatus = devicePolicyManager.getStorageEncryptionStatus();
+        if (config.remindBackupSeed())
+            return Warning.BACKUP_SEED;
         if (config.remindBackup())
             return Warning.BACKUP;
         else if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP

--- a/wallet/src/de/schildbach/wallet/ui/widget/UpgradeWalletDisclaimerDialog.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/UpgradeWalletDisclaimerDialog.java
@@ -17,6 +17,8 @@
 
 package de.schildbach.wallet.ui.widget;
 
+import android.app.Activity;
+import android.app.AlertDialog;
 import android.app.Dialog;
 import android.app.DialogFragment;
 import android.app.FragmentManager;
@@ -27,6 +29,7 @@ import android.view.LayoutInflater;
 import android.view.View;
 import android.view.ViewGroup;
 
+import de.schildbach.wallet.ui.BackupWalletToSeedDialogFragment;
 import de.schildbach.wallet.ui.DialogBuilder;
 import de.schildbach.wallet_test.R;
 
@@ -55,13 +58,21 @@ public class UpgradeWalletDisclaimerDialog extends DialogFragment {
         dialogBuilder.setMessage(message);
         dialogBuilder.setCancelable(false);
         dialogBuilder.setPositiveButton(android.R.string.ok, null);
-        dialogBuilder.setPositiveButton(R.string.wallet_options_encrypt_keys_set,
+
+        String buttonText = getString(R.string.export_keys_dialog_title_to_seed) + " / " + getString(R.string.wallet_options_encrypt_keys_set);
+        dialogBuilder.setPositiveButton(buttonText,
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(final DialogInterface dialog, final int which) {
-                        if (getActivity() instanceof OnUpgradeConfirmedListener) {
-                            ((OnUpgradeConfirmedListener) getActivity()).onUpgradeConfirmed();
-                        }
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
+                            @Override
+                            public void onDismiss(DialogInterface dialog) {
+                                Activity activity = ((AlertDialog)dialog).getOwnerActivity();
+                                if (activity instanceof OnUpgradeConfirmedListener) {
+                                    ((OnUpgradeConfirmedListener) activity).onUpgradeConfirmed();
+                                }
+                            }
+                        });
                     }
                 });
 

--- a/wallet/src/de/schildbach/wallet/util/CrashReporter.java
+++ b/wallet/src/de/schildbach/wallet/util/CrashReporter.java
@@ -216,6 +216,11 @@ public class CrashReporter {
         report.append("Time of backup: "
                 + (lastBackupTime > 0 ? String.format(Locale.US, "%tF %tT %tZ", calendar, calendar, calendar) : "none")
                 + "\n");
+        final long lastBackupSeedTime = configuration.getLastBackupSeedTime();
+        calendar.setTimeInMillis(lastBackupTime);
+        report.append("Time of seed backup: "
+                + (lastBackupSeedTime > 0 ? String.format(Locale.US, "%tF %tT %tZ", calendar, calendar, calendar) : "none")
+                + "\n");
         report.append("Network: " + Constants.NETWORK_PARAMETERS.getId() + "\n");
         final Wallet wallet = application.getWallet();
         report.append("Encrypted: " + wallet.isEncrypted() + "\n");

--- a/wallet/src/de/schildbach/wallet/util/WalletUtils.java
+++ b/wallet/src/de/schildbach/wallet/util/WalletUtils.java
@@ -170,7 +170,9 @@ public class WalletUtils {
         } catch (final IOException x) {
             try {
                 is.reset();
-                return restorePrivateKeysFromBase58(is, expectedNetworkParameters);
+                Wallet wallet = restorePrivateKeysFromBase58(is, expectedNetworkParameters);
+                wallet.upgradeToDeterministic(null); //this will result in a different HD seed each time
+                return wallet;
             } catch (final IOException x2) {
                 throw new IOException(
                         "cannot read protobuf (" + x.getMessage() + ") or base58 (" + x2.getMessage() + ")", x);


### PR DESCRIPTION
* Show the recovery phrase when upgrading to BIP44/Set PIN (Lock)
* Add a backup status and time for the recovery phrase to the configuration and Crash Report
* Add a checkbox to the View Recovery Phrase Dialog for writing down the phrase

This checkbox is purposefully missing the first time the recovery phrase dialog is displayed during the upgrade process.  Later, the app will ask the user to backup (top message on the transactions list).  At that point, if the users clicks "backup" and shows the recovery phrase -- the user can check the box and will not be reminded again.  This is probably no the best way to do it, but it can help trigger our minds to determine a better way to remind the user twice.  For users that have upgraded, the reminder on the main screen will be the way to get them to write it down.

* Set a reminder to backup the recovery phrase on the main screen (TransactionsAdapter)
* Arm backup Reminders when restoring from a key backup file (old format)