### PR TITLE
Preventing Crash when Dialogs are recreated

### DIFF
--- a/wallet/res/values-es/strings-extra.xml
+++ b/wallet/res/values-es/strings-extra.xml
@@ -67,6 +67,7 @@
 	<string name="encrypt_new_key_chain_dialog_message">Tu billetera será actualizada para admitir la importación y exportación a otras aplicaciones.</string>
 	<string name="encrypt_new_key_chain_enter_pin_dialog_message">Debes ingresar tu PIN para finalizar el proceso de actualización.</string>
 	<string name="pin_code_required_dialog_message">Esta aplicación ahora requiere un PIN para gastos y también para ver su saldo y transacciones.</string>
+    <string name="backup_wallet_seed_private_key_written_down_box">He anotado la frase de recuperación</string>
 
 
 </resources>

--- a/wallet/res/values-pt-rBR/strings-extra.xml
+++ b/wallet/res/values-pt-rBR/strings-extra.xml
@@ -67,6 +67,7 @@
 	<string name="encrypt_new_key_chain_dialog_message">Sua carteira será atualizada para suportar importação e exportação para mais aplicativos.</string>
 	<string name="encrypt_new_key_chain_enter_pin_dialog_message">Você deve inserir seu PIN para finalizar o processo de atualização.</string>
 	<string name="pin_code_required_dialog_message">Este app agora requer um PIN para gastos e também para ver seu saldo e transações.</string>
+    <string name="backup_wallet_seed_private_key_written_down_box">Eu anotei a frase de recuperação</string>
 
 
 </resources>

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
@@ -225,12 +225,7 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
                 EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
                     @Override
                     public void onDismiss(DialogInterface dialog) {
-                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
-                            @Override
-                            public void onDismiss(DialogInterface dialog) {
-                                onUpgradeConfirmed();
-                            }
-                        });
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
                     }
                 }, path);
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/RestoreWalletActivity.java
@@ -56,7 +56,8 @@ import android.widget.EditText;
  * @author Andreas Schildbach
  */
 public final class RestoreWalletActivity extends AbstractWalletActivity
-        implements UpgradeWalletDisclaimerDialog.OnUpgradeConfirmedListener {
+        implements UpgradeWalletDisclaimerDialog.OnUpgradeConfirmedListener,
+        EncryptNewKeyChainDialogFragment.OnNewKeyChainEncryptedListener {
     private static final int DIALOG_RESTORE_WALLET = 0;
 
     private WalletApplication application;
@@ -68,9 +69,9 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
 
     enum State {
         INPUT, UPGRADE, PINSET, DONE;
+
     }
     State state = State.INPUT;
-
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -203,17 +204,17 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
     }
 
     private class FinishListener implements DialogInterface.OnClickListener, DialogInterface.OnCancelListener {
+
         @Override
         public void onClick(final DialogInterface dialog, final int which) {
             finish();
         }
-
         @Override
         public void onCancel(final DialogInterface dialog) {
             finish();
         }
-    }
 
+    }
     private final FinishListener finishListener = new FinishListener();
 
     private void upgradeWalletKeyChains(final ImmutableList<ChildNumber> path) {
@@ -222,12 +223,7 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
         if (!wallet.hasKeyChain(path)) {
             if (wallet.isEncrypted()) {
                 state = State.PINSET;
-                EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
-                    @Override
-                    public void onDismiss(DialogInterface dialog) {
-                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
-                    }
-                }, path);
+                EncryptNewKeyChainDialogFragment.show(getFragmentManager(), path);
             } else {
                 //
                 // Upgrade the wallet now
@@ -291,5 +287,10 @@ public final class RestoreWalletActivity extends AbstractWalletActivity
                 onUpgradeConfirmed();
             }
         });
+    }
+
+    @Override
+    public void onNewKeyChainEncrypted() {
+        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
     }
 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -105,7 +105,8 @@ import android.widget.TextView;
 public final class WalletActivity extends AbstractBindServiceActivity
         implements ActivityCompat.OnRequestPermissionsResultCallback,
         NavigationView.OnNavigationItemSelectedListener,
-        WalletLock.OnLockChangeListener, UpgradeWalletDisclaimerDialog.OnUpgradeConfirmedListener {
+        WalletLock.OnLockChangeListener, UpgradeWalletDisclaimerDialog.OnUpgradeConfirmedListener,
+        EncryptNewKeyChainDialogFragment.OnNewKeyChainEncryptedListener {
     private static final int DIALOG_BACKUP_WALLET_PERMISSION = 0;
     private static final int DIALOG_RESTORE_WALLET_PERMISSION = 1;
     private static final int DIALOG_RESTORE_WALLET = 2;
@@ -1089,12 +1090,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         isRestoringBackup = restoreBackup;
         if (!wallet.hasKeyChain(path)) {
             if (wallet.isEncrypted()) {
-                EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
-                    @Override
-                    public void onDismiss(DialogInterface dialog) {
-                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
-                    }
-                }, path);
+                EncryptNewKeyChainDialogFragment.show(getFragmentManager(), path);
             } else {
                 //
                 // Upgrade the wallet now
@@ -1128,4 +1124,8 @@ public final class WalletActivity extends AbstractBindServiceActivity
         }
     }
 
+    @Override
+    public void onNewKeyChainEncrypted() {
+        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
+    }
 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1092,13 +1092,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
                 EncryptNewKeyChainDialogFragment.show(getFragmentManager(), new DialogInterface.OnDismissListener() {
                     @Override
                     public void onDismiss(DialogInterface dialog) {
-                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
-                            @Override
-                            public void onDismiss(DialogInterface dialog) {
-                                if(isRestoringBackup)
-                                    resetBlockchain();
-                            }
-                        });
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
                     }
                 }, path);
             } else {

--- a/wallet/src/de/schildbach/wallet/ui/widget/UpgradeWalletDisclaimerDialog.java
+++ b/wallet/src/de/schildbach/wallet/ui/widget/UpgradeWalletDisclaimerDialog.java
@@ -64,15 +64,7 @@ public class UpgradeWalletDisclaimerDialog extends DialogFragment {
                 new DialogInterface.OnClickListener() {
                     @Override
                     public void onClick(final DialogInterface dialog, final int which) {
-                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true, new DialogInterface.OnDismissListener() {
-                            @Override
-                            public void onDismiss(DialogInterface dialog) {
-                                Activity activity = ((AlertDialog)dialog).getOwnerActivity();
-                                if (activity instanceof OnUpgradeConfirmedListener) {
-                                    ((OnUpgradeConfirmedListener) activity).onUpgradeConfirmed();
-                                }
-                            }
-                        });
+                        BackupWalletToSeedDialogFragment.show(getFragmentManager(), true);
                     }
                 });
 

--- a/wallet/src/de/schildbach/wallet/util/ParcelableChainPath.java
+++ b/wallet/src/de/schildbach/wallet/util/ParcelableChainPath.java
@@ -1,0 +1,68 @@
+package de.schildbach.wallet.util;
+
+import android.os.Parcel;
+import android.os.Parcelable;
+import android.support.annotation.NonNull;
+
+import com.google.common.collect.ImmutableList;
+
+import org.bitcoinj.crypto.ChildNumber;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by Sam Barbosa on 5/22/2018.
+ */
+public class ParcelableChainPath implements Parcelable {
+
+    private int[] childNumberArr;
+
+    public ParcelableChainPath(List<ChildNumber> childNumberList) {
+        int size = childNumberList.size();
+        childNumberArr = new int[size];
+        int i = 0;
+        while (i < size) {
+            childNumberArr[i] = childNumberList.get(i).getI();
+            i++;
+        }
+    }
+
+    public ParcelableChainPath(Parcel source) {
+        childNumberArr = source.createIntArray();
+    }
+
+    @Override
+    public int describeContents() {
+        return 0;
+    }
+
+    @Override
+    public void writeToParcel(Parcel dest, int flags) {
+        dest.writeIntArray(childNumberArr);
+    }
+
+    public static final Parcelable.Creator<ParcelableChainPath> CREATOR = new Parcelable.Creator<ParcelableChainPath>() {
+
+        @Override
+        public ParcelableChainPath createFromParcel(Parcel source) {
+            return new ParcelableChainPath(source);
+        }
+
+        @Override
+        public ParcelableChainPath[] newArray(int size) {
+            return new ParcelableChainPath[size];
+        }
+
+    };
+
+    @NonNull
+    public ImmutableList<ChildNumber> getPath() {
+        List<ChildNumber> childNumberList = new ArrayList<>();
+        for (int i : childNumberArr) {
+            childNumberList.add(new ChildNumber(i));
+        }
+        return ImmutableList.copyOf(childNumberList);
+    }
+
+}


### PR DESCRIPTION
# Description
- This PR prevents crashes when Wallet is being Upgraded and the onboarding dialogs get recreated by the system (device rotation, app coming from bg with low memory, etc).