### PR TITLE
Closing Drawer menu when pressing back

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1079,6 +1079,16 @@ public final class WalletActivity extends AbstractBindServiceActivity
         viewDrawer.closeDrawer(GravityCompat.START);
         return true;
     }
+
+    @Override
+    public void onBackPressed() {
+        if (viewDrawer.isDrawerOpen(GravityCompat.START)) {
+            viewDrawer.closeDrawer(GravityCompat.START);
+        } else {
+            super.onBackPressed();
+        }
+    }
+
     //Dash Specific
     private void handleDisconnect() {
         getWalletApplication().stopBlockchainService();


### PR DESCRIPTION
# Description
- Preventing sending the app to background when pressing back while the drawer menu is open.

# Evidence
### Before
<img src="https://user-images.githubusercontent.com/564039/43598533-819fbe32-964a-11e8-9575-6a15c15ad0ae.gif" width="320" />

### After
<img src="https://user-images.githubusercontent.com/564039/43598551-8ee580fe-964a-11e8-97f2-bc55bd69755d.gif" width="320" />
