### PR TITLE
Transaction States

### DIFF
--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -9,7 +9,7 @@
 	<string name="transaction_row_message_received_instantx_locked">This InstantSend payment has been verified by the Dash Network.</string>
 	<string name="transaction_row_message_received_unconfirmed_instantx">Unconfirmed InstantSend</string>
 	<string name="transaction_row_message_received_instantx_locked2">Locked InstantSend</string>
-
+	<string name="transaction_row_message_sent_to_single_peer">This payment has been sent.</string>
 	<string name="wallet_options_disconnect">Disconnect</string>
 
 	<string name="network_monitor_masternodes_title">Masternodes</string>

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -662,6 +662,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
                     peerGroup.broadcastTransaction(tx, minimum);
                 } else {
                     log.info("peergroup not available, not broadcasting transaction " + tx.getHashAsString());
+                    tx.getConfidence().setPeerInfo(0, 1);
                 }
             }
         } else {

--- a/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
@@ -367,6 +367,8 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             final boolean isIX = confidence.isIX();
             final boolean isLocked = confidence.isTransactionLocked();
+            final boolean sentToSinglePeer = confidence.getPeerCount() == 1;
+            final boolean sentToSinglePeerSuccessful = sentToSinglePeer ? confidence.isSent() : false;
 
             TransactionCacheEntry txCache = transactionCache.get(tx.getHash());
             if (txCache == null) {
@@ -566,6 +568,12 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             } else if (purpose == Purpose.RAISE_FEE) {
                 extendMessageView.setVisibility(View.VISIBLE);
                 messageView.setText(R.string.transaction_row_message_purpose_raise_fee);
+                messageView.setTextColor(colorInsignificant);
+            }  else if (isOwn && confidenceType == ConfidenceType.PENDING && sentToSinglePeer && txCache.isLocked == false && confidence.numBroadcastPeers() == 0) {
+                extendMessageView.setVisibility(View.VISIBLE);
+                if(sentToSinglePeerSuccessful)
+                    messageView.setText(R.string.transaction_row_message_sent_to_single_peer);
+                else messageView.setText(R.string.transaction_row_message_own_unbroadcasted);
                 messageView.setTextColor(colorInsignificant);
             } else if (isOwn && confidenceType == ConfidenceType.PENDING && confidence.numBroadcastPeers() == 0) {
                 extendMessageView.setVisibility(View.VISIBLE);

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -340,7 +340,8 @@ public final class SendCoinsFragment extends Fragment {
                         if (confidenceType == ConfidenceType.DEAD) {
                             setState(State.FAILED);
                         } else if (numBroadcastPeers >= 1 || confidenceType == ConfidenceType.BUILDING ||
-                                ixType == TransactionConfidence.IXType.IX_LOCKED) {
+                                ixType == TransactionConfidence.IXType.IX_LOCKED ||
+                                (confidence.getPeerCount() == 1 && confidence.isSent())) {
                             setState(State.SENT);
 
                             // Auto-close the dialog after a short delay
@@ -356,7 +357,8 @@ public final class SendCoinsFragment extends Fragment {
                     }
 
                     if (reason == ChangeReason.SEEN_PEERS && confidenceType == ConfidenceType.PENDING ||
-                            reason == ChangeReason.IX_TYPE && ixType == TransactionConfidence.IXType.IX_LOCKED) {
+                            reason == ChangeReason.IX_TYPE && ixType == TransactionConfidence.IXType.IX_LOCKED||
+                            (confidence.getPeerCount() == 1 && confidence.isSent())) {
                         // play sound effect
                         final int soundResId = getResources().getIdentifier("send_coins_broadcast_" + numBroadcastPeers,
                                 "raw", activity.getPackageName());


### PR DESCRIPTION
There are two objectives:
1.  Notify the user if a transaction was sent to only 1 peer (due to being connected to only 1 peer).  Previously the app stated that "the payment has not been transmitted".

2.  Simplify the various transaction statuses to include simplier InstantSend and allowed 0-conf (this is not yet included)

This requires an updated dashj, which is in the https://github.com/HashEngineering/dashj/pull/19 pull request.  A new version commit is not included in the dashj PR.  It will need to be built locally for testing.