### PR TITLE
Transaction State Messages

### DIFF
--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -23,7 +23,7 @@ dependencies {
     compile 'com.android.support:support-core-utils:25.1.1'
     compile 'com.android.support:recyclerview-v7:25.1.1'
     compile 'com.android.support:cardview-v7:25.1.1'
-    compile 'org.dashj:dashj-core:0.14.4.5'
+    compile 'org.dashj:dashj-core:0.14.4.6'
     compile 'com.google.protobuf:protobuf-java:2.6.1'
     compile 'com.google.guava:guava:20.0'
     compile 'com.google.zxing:core:3.3.0'

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -3,10 +3,10 @@
 
 	<string name="send_coins_fragment_instantx_enable">Use InstantSend</string>
 	<string name="transaction_row_message_own_instantx_lock_request_notsent">This InstantSend payment has not been transmitted yet.</string>
-	<string name="transaction_row_message_own_instantx_lock_request">This InstantSend payment is awaiting verification by the Dash Network.</string>
+	<string name="transaction_row_message_own_instantx_lock_request">This InstantSend payment is awaiting verification.</string>
 	<string name="transaction_row_message_own_instantx_locked">Sent InstantSend transaction (locked)</string>
-	<string name="transaction_row_message_received_instantx_lock_request">This InstantSend payment is awaiting verification by the Dash Network.</string>
-	<string name="transaction_row_message_received_instantx_locked">This InstantSend payment has been verified by the Dash Network.</string>
+	<string name="transaction_row_message_received_instantx_lock_request">This InstantSend payment is awaiting verification.</string>
+	<string name="transaction_row_message_received_instantx_locked">InstantSend verified</string>
 	<string name="transaction_row_message_received_unconfirmed_instantx">Unconfirmed InstantSend</string>
 	<string name="transaction_row_message_received_instantx_locked2">Locked InstantSend</string>
 	<string name="transaction_row_message_sent_to_single_peer">This payment has been sent.</string>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -9,7 +9,7 @@
 	<string name="transaction_row_message_received_instantx_locked">This InstantSend payment has been verified by the Dash Network.</string>
 	<string name="transaction_row_message_received_unconfirmed_instantx">Unconfirmed InstantSend</string>
 	<string name="transaction_row_message_received_instantx_locked2">Locked InstantSend</string>
-
+	<string name="transaction_row_message_sent_to_single_peer">This payment has been sent.</string>
 	<string name="wallet_options_disconnect">Disconnect</string>
 
 	<string name="network_monitor_masternodes_title">Masternodes</string>

--- a/wallet/res/values/strings.xml
+++ b/wallet/res/values/strings.xml
@@ -163,7 +163,7 @@
     <string name="transaction_row_message_own_unbroadcasted">This payment has not been transmitted yet.</string>
     <string name="transaction_row_message_received_direct">This payment has been received directly. There is a risk it might never become spendable.</string>
     <string name="transaction_row_message_received_unconfirmed_delayed">The confirmation of this payment is delayed, likely due to an overload of the Dash network.</string>
-    <string name="transaction_row_message_received_unconfirmed_unlocked">This payment should become spendable in a few minutes.</string>
+    <string name="transaction_row_message_received_unconfirmed_unlocked">This payment can be spent now without being confirmed.</string>
     <string name="transaction_row_message_received_in_conflict">This payment has an increased risk of being reversed by the sender! If you can, wait for confirmation.</string>
     <string name="transaction_row_message_received_dead">This payment has been reversed by the sender.</string>
     <string name="transaction_row_message_received_dust">This small amount can probably never be spent economically.</string>

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -662,6 +662,7 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
                     peerGroup.broadcastTransaction(tx, minimum);
                 } else {
                     log.info("peergroup not available, not broadcasting transaction " + tx.getHashAsString());
+                    tx.getConfidence().setPeerInfo(0, 1);
                 }
             }
         } else {

--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -649,15 +649,9 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
                     log.info("broadcasting transaction " + tx.getHashAsString());
                     int count = peerGroup.numConnectedPeers();
                     int minimum = peerGroup.getMinBroadcastConnections();
-                    switch(count) {
-                        case 1:
-                            minimum = 1;
-                            break;
-                        case 2:
-                        case 3:
-                            minimum = 2;
-                            break;
-                    }
+                    //if the number of peers is <= 3, then only require that number of peers to send
+                    if(count <= 3)
+                        minimum = count;
 
                     peerGroup.broadcastTransaction(tx, minimum);
                 } else {

--- a/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
@@ -367,6 +367,8 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             final boolean isIX = confidence.isIX();
             final boolean isLocked = confidence.isTransactionLocked();
+            final boolean sentToSinglePeer = confidence.getPeerCount() == 1;
+            final boolean sentToSinglePeerSuccessful = sentToSinglePeer ? confidence.isSent() : false;
 
             TransactionCacheEntry txCache = transactionCache.get(tx.getHash());
             if (txCache == null) {
@@ -566,6 +568,12 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
             } else if (purpose == Purpose.RAISE_FEE) {
                 extendMessageView.setVisibility(View.VISIBLE);
                 messageView.setText(R.string.transaction_row_message_purpose_raise_fee);
+                messageView.setTextColor(colorInsignificant);
+            }  else if (isOwn && confidenceType == ConfidenceType.PENDING && sentToSinglePeer && txCache.isLocked == false && confidence.numBroadcastPeers() == 0) {
+                extendMessageView.setVisibility(View.VISIBLE);
+                if(sentToSinglePeerSuccessful)
+                    messageView.setText(R.string.transaction_row_message_sent_to_single_peer);
+                else messageView.setText(R.string.transaction_row_message_own_unbroadcasted);
                 messageView.setTextColor(colorInsignificant);
             } else if (isOwn && confidenceType == ConfidenceType.PENDING && confidence.numBroadcastPeers() == 0) {
                 extendMessageView.setVisibility(View.VISIBLE);

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -340,7 +340,8 @@ public final class SendCoinsFragment extends Fragment {
                         if (confidenceType == ConfidenceType.DEAD) {
                             setState(State.FAILED);
                         } else if (numBroadcastPeers >= 1 || confidenceType == ConfidenceType.BUILDING ||
-                                ixType == TransactionConfidence.IXType.IX_LOCKED) {
+                                ixType == TransactionConfidence.IXType.IX_LOCKED ||
+                                (confidence.getPeerCount() == 1 && confidence.isSent())) {
                             setState(State.SENT);
 
                             // Auto-close the dialog after a short delay
@@ -356,7 +357,8 @@ public final class SendCoinsFragment extends Fragment {
                     }
 
                     if (reason == ChangeReason.SEEN_PEERS && confidenceType == ConfidenceType.PENDING ||
-                            reason == ChangeReason.IX_TYPE && ixType == TransactionConfidence.IXType.IX_LOCKED) {
+                            reason == ChangeReason.IX_TYPE && ixType == TransactionConfidence.IXType.IX_LOCKED||
+                            (confidence.getPeerCount() == 1 && confidence.isSent())) {
                         // play sound effect
                         final int soundResId = getResources().getIdentifier("send_coins_broadcast_" + numBroadcastPeers,
                                 "raw", activity.getPackageName());


### PR DESCRIPTION
There are two objectives:

Notify the user if a transaction was sent to only 1 peer (due to being connected to only 1 peer). Previously the app stated that "the payment has not been transmitted".

Simplify the various transaction statuses to include simplier InstantSend and allowed 0-conf (this is not yet included)