### PR TITLE
Use Masternode List as Seed Peers if DNS seeders return no peers

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -17,6 +17,7 @@ buildscript {
 
 allprojects {
     repositories {
+        mavenLocal()
         jcenter()
         maven {
             url 'https://maven.google.com/'

--- a/sample-integration-android/build.gradle
+++ b/sample-integration-android/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation(project(':integration-android')) {
         exclude(group: 'com.google.android', module: 'android')
     }
-    implementation 'org.dashj:dashj-core:0.14.4.5'
+    implementation 'org.dashj:dashj-core:0.14.4.7'
 }
 
 android {

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation "com.android.support:support-core-utils:$androidSupportVersion"
     implementation "com.android.support:recyclerview-v7:$androidSupportVersion"
     implementation "com.android.support:cardview-v7:$androidSupportVersion"
-    implementation 'org.dashj:dashj-core:0.14.4.6'
+    implementation 'org.dashj:dashj-core:0.14.4.7'
     implementation 'com.google.protobuf:protobuf-java:2.6.1'
     implementation 'com.google.guava:guava:20.0'
     implementation 'com.google.zxing:core:3.3.0'


### PR DESCRIPTION
The List of seed peers for MainNet and TestNet was added to dashj 0.14.4.7.

If the DNS seeders don't return any peers, dashj throws a PeerDiscoveryException.  The code added catches this exception and attempts to connect to the Seed Peers (about 300 masternodes).