### PR TITLE
Add Wallet Lock Timer

### DIFF
--- a/wallet/src/de/schildbach/wallet/Configuration.java
+++ b/wallet/src/de/schildbach/wallet/Configuration.java
@@ -74,6 +74,7 @@ public class Configuration {
     private static final String PREFS_KEY_LAST_BACKUP_SEED = "last_backup_seed";
     public static final String PREFS_KEY_INSTANTX_ENABLED = "labs_instantx_enabled";
     public static final String PREFS_KEY_LITE_MODE = "labs_lite_mode";
+    public final static String PREFS_LAST_UNLOCK_TIME = "last_unlock_time";
 
     private static final int PREFS_DEFAULT_BTC_SHIFT = 0;
     private static final int PREFS_DEFAULT_BTC_PRECISION = 4;
@@ -337,5 +338,13 @@ public class Configuration {
 
     public boolean getLiteMode() {
         return prefs.getBoolean(PREFS_KEY_LITE_MODE, true);
+    }
+
+    public long getLastUnlockTime() {
+        return prefs.getLong(PREFS_LAST_UNLOCK_TIME, 0);
+    }
+
+    public void setLastUnlockTime(long unlockTime) {
+        prefs.edit().putLong(PREFS_LAST_UNLOCK_TIME, unlockTime).apply();
     }
 }

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -566,7 +566,7 @@ public void updateDashMode()
 
     private void lockWalletIfNeeded() {
         WalletLock walletLock = WalletLock.getInstance();
-        if (wallet.isEncrypted() && !walletLock.isWalletLocked(wallet)) {
+        if (walletLock.isWalletLocked(wallet)) {
             walletLock.setWalletLocked(true);
         }
     }
@@ -578,9 +578,7 @@ public void updateDashMode()
 
     @Override
     public void onActivityStarted(Activity activity) {
-        if (numStarted == 0) {
-            lockWalletIfNeeded();
-        }
+        lockWalletIfNeeded();
         numStarted++;
     }
 

--- a/wallet/src/de/schildbach/wallet/data/WalletLock.java
+++ b/wallet/src/de/schildbach/wallet/data/WalletLock.java
@@ -18,15 +18,24 @@
 package de.schildbach.wallet.data;
 
 import org.bitcoinj.wallet.Wallet;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import de.schildbach.wallet.Configuration;
+
 public class WalletLock {
+
+    protected static final Logger log = LoggerFactory.getLogger(WalletLock.class);
+
 
     private List<OnLockChangeListener> listeners = new ArrayList<>();
 
-    private boolean walletLocked = true;
+    private static int DEFAULT_LOCK_TIMER_MILLIS = 1000 * 60 * 3; // 3 Minutes
+
+    private Configuration config;
 
     private static WalletLock instance;
 
@@ -40,11 +49,14 @@ public class WalletLock {
     }
 
     public boolean isWalletLocked(Wallet wallet) {
-        return walletLocked && wallet.isEncrypted();
+        boolean isTimerExpired = config.getLastUnlockTime() + DEFAULT_LOCK_TIMER_MILLIS < System.currentTimeMillis();
+        return isTimerExpired && wallet.isEncrypted();
     }
 
     public void setWalletLocked(boolean walletLocked) {
-        this.walletLocked = walletLocked;
+        log.info(walletLocked ? "Locking" : "Unlocking" + "wallet");
+        if(walletLocked)
+            config.setLastUnlockTime(0);
         for (OnLockChangeListener listener : listeners) {
             listener.onLockChanged(walletLocked);
         }
@@ -60,6 +72,10 @@ public class WalletLock {
 
     public interface OnLockChangeListener {
         void onLockChanged(boolean locked);
+    }
+
+    public void setConfiguration(Configuration config) {
+        this.config = config;
     }
 
 }

--- a/wallet/src/de/schildbach/wallet/ui/UnlockWalletDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/UnlockWalletDialogFragment.java
@@ -56,7 +56,7 @@ public class UnlockWalletDialogFragment extends AbstractPINDialogFragment {
             @Override
             protected void onSuccess() {
                 if (getActivity() != null && isAdded()) {
-                    pinRetryController.successfulAttempt();
+                    pinRetryController.successfulAttempt(application.getConfiguration());
                     WalletLock.getInstance().setWalletLocked(false);
                     dismissAllowingStateLoss();
                 }

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -140,6 +140,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
         application = getWalletApplication();
         config = application.getConfiguration();
         wallet = application.getWallet();
+        WalletLock.getInstance().setConfiguration(config);
 
         setContentView(R.layout.wallet_activity_onepane_vertical);
 

--- a/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
+++ b/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
@@ -6,11 +6,15 @@ import android.content.DialogInterface;
 import android.content.SharedPreferences;
 import android.widget.Toast;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
 import java.util.Date;
 import java.util.HashSet;
 import java.util.Set;
 import java.util.concurrent.TimeUnit;
 
+import de.schildbach.wallet.Configuration;
 import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet_test.R;
 
@@ -27,6 +31,8 @@ public class PinRetryController {
     private final static int POW_LOCK_TIME_BASE = 6;
     private final static int FAIL_LIMIT = 8;
     private final static long ONE_MINUTE_MILLIS = TimeUnit.MINUTES.toMillis(1);
+
+    private static final Logger log = LoggerFactory.getLogger(PinRetryController.class);
 
     public PinRetryController(Context context) {
         this.context = context;
@@ -58,6 +64,18 @@ public class PinRetryController {
         prefsEditor.remove(PREFS_FAIL_HEIGHT);
         prefsEditor.remove(PREFS_FAILED_PINS);
         prefsEditor.apply();
+        log.info("PIN entered successfully");
+    }
+
+    /**
+     * When the PIN is entered successfully, save the time it was entered.
+     * @param config
+     */
+    public void successfulAttempt(Configuration config) {
+        long secureTime = prefs.getLong(PREFS_SECURE_TIME, System.currentTimeMillis());
+        config.setLastUnlockTime(secureTime);
+        successfulAttempt();
+        log.info("PIN entered successfully at " + secureTime/1000);
     }
 
     public void failedAttempt(String pin) {
@@ -70,6 +88,7 @@ public class PinRetryController {
             int failCount = failedPins.size();
             SharedPreferences.Editor prefsEditor = prefs.edit();
             prefsEditor.putStringSet(PREFS_FAILED_PINS, failedPins);
+            log.info("PIN entered incorrectly " + failCount + "times");
 
             if (failCount >= FAIL_LIMIT) {
                 wipeWallet();
@@ -120,6 +139,7 @@ public class PinRetryController {
         dialogBuilder.setNegativeButton(android.R.string.yes, new DialogInterface.OnClickListener() {
             @Override
             public void onClick(DialogInterface dialog, int which) {
+                log.info("Clearing all app data and exiting.");
                 WalletApplication.getInstance().clearDataAndExit();
             }
         });
@@ -137,6 +157,7 @@ public class PinRetryController {
     private void wipeWallet() {
         Toast.makeText(context, "Locked 4ever. Wiping wallet... ", Toast.LENGTH_SHORT).show();
         //TODO: WIPE WALLET AND CLOSE THE APP
+        log.info("Locked 4ever. Wiping wallet... (function not implimented)");
     }
 
     public void storeSecureTime(Date date) {

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1091,7 +1091,7 @@ public final class SendCoinsFragment extends Fragment {
             @Override
             protected void onSuccess(final Transaction transaction) {
                 if (pin != null) {
-                    pinRetryController.successfulAttempt();
+                    pinRetryController.successfulAttempt(config);
                 }
                 sentTransaction = transaction;
 


### PR DESCRIPTION
This adds a 3 minute "timer" based on the secure time when a PIN is entered correctly.

This means that for 3 minutes the app will remained unlocked.  After 3 minutes the app will lock if the user switches to a new app or the device locks itself.  Not sure about the exact timing as I don't know how often the secure time value is updated in the app.  

The 3 minute timer is activated if:
1.  The app is unlocked on any activity with the unlock function
2.  The user sends coins (which requires a PIN) which now unlocks the app.

Other functions that require a PIN do not unlock the app, such as Backup and Viewing the recovery phrase.