### PR TITLE
Use dashj 0.14.7

### DIFF
--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -27,7 +27,7 @@ dependencies {
     implementation "com.android.support:support-core-utils:$androidSupportVersion"
     implementation "com.android.support:recyclerview-v7:$androidSupportVersion"
     implementation "com.android.support:cardview-v7:$androidSupportVersion"
-    implementation 'org.dashj:dashj-core:0.14.4.7'
+    implementation 'org.dashj:dashj-core:0.14.7'
     implementation 'com.google.protobuf:protobuf-java:2.6.1'
     implementation 'com.google.guava:guava:20.0'
     implementation 'com.google.zxing:core:3.3.0'


### PR DESCRIPTION
This will fail the Travis CI test due to a missing dashj-core-0.14.7.

This will also have merge conflicts with the Rebranding PR#136.