### PR TITLE
Resolve Delayed Sending from v5.18.3+

### DIFF
--- a/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
+++ b/wallet/src/de/schildbach/wallet/service/BlockchainServiceImpl.java
@@ -696,7 +696,8 @@ public class BlockchainServiceImpl extends android.app.Service implements Blockc
                     int count = peerGroup.numConnectedPeers();
                     int minimum = peerGroup.getMinBroadcastConnections();
                     //if the number of peers is <= 3, then only require that number of peers to send
-                    if(count <= 3)
+                    //if the number of peers is 0, then require 3 peers (default min connections)
+                    if(count > 0 && count <= 3)
                         minimum = count;
 
                     peerGroup.broadcastTransaction(tx, minimum);


### PR DESCRIPTION
BlockchainServiceImpl:  Set min peers to send > 1
* Before: 0 minimum peers was possible (resulted in exception in dashj)
* If connected peers = 1, 2, 3, then send to that many peers
* If there are no connected peers, wait for 3