### PR TITLE
Fix wallet wipe

### DIFF
--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -40,7 +40,7 @@
 	<string name="wallet_lock_unlock_dialog_title">Unlock your wallet</string>
 	<string name="wallet_lock_unlock_dialog_message">Your wallet is protected by a spending PIN. Enter your PIN and press Unlock to continue.</string>
 	<string name="wallet_lock_reset_wallet_title">Reset wallet</string>
-	<string name="wallet_lock_reset_wallet_message">Are you sure? All stored data will be deleted and your wallet will only be recoverable by a backup file or recovery seed.</string>
+	<string name="wallet_lock_reset_wallet_message">Are you sure? Your wallet will be deleted and all your Dash will be lost.\n\nThe only way to recover your Dash is with a backup file or recovery phrase.</string>
 
 	<string name="wallet_lock_wallet_disabled">Wallet disabled</string>
 	<string name="wallet_lock_try_again">Try again in %1$d %2$s</string>

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -613,37 +613,29 @@ public void updateDashMode()
 
     }
 
+    /**
+      Replace the wallet with an new wallet as part of a wallet wipe
+     */
     private void clearApplicationData() {
-        File cacheDirectory = getCacheDir();
-        File applicationDirectory = new File(cacheDirectory.getParent());
-        if (applicationDirectory.exists()) {
-            String[] fileNames = applicationDirectory.list();
-            for (String fileName : fileNames) {
-                if (!fileName.equals("lib")) {
-                    deleteFile(new File(applicationDirectory, fileName));
-                }
-            }
-        }
-    }
+        Wallet newWallet = new Wallet(Constants.NETWORK_PARAMETERS);
+        newWallet.addKeyChain(Constants.BIP44_PATH);
 
-    private static boolean deleteFile(File file) {
-        boolean deletedAll = true;
-        if (file != null) {
-            if (file.isDirectory()) {
-                String[] children = file.list();
-                for (int i = 0; i < children.length; i++) {
-                    deletedAll = deleteFile(new File(file, children[i])) && deletedAll;
-                }
-            } else {
-                deletedAll = file.delete();
-            }
-        }
+        log.info("creating new wallet after wallet wipe");
 
-        return deletedAll;
+        File walletBackupFile = getFileStreamPath(Constants.Files.WALLET_KEY_BACKUP_PROTOBUF);
+        if(walletBackupFile.exists())
+            walletBackupFile.delete();
+
+        replaceWallet(newWallet);
+        saveWallet();
+        config.armBackupReminder();
+        config.armBackupSeedReminder();
+        log.info("New wallet created to replace the wiped locked wallet");
     }
 
     public void clearDataAndExit() {
         clearApplicationData();
+        log.info("closing app after wallet wipe");
         Process.killProcess(Process.myPid());
         System.exit(1);
     }

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -616,7 +616,7 @@ public void updateDashMode()
     /**
       Replace the wallet with an new wallet as part of a wallet wipe
      */
-    private void clearApplicationData() {
+    public void eraseAndCreateNewWallet() {
         Wallet newWallet = new Wallet(Constants.NETWORK_PARAMETERS);
         newWallet.addKeyChain(Constants.BIP44_PATH);
 
@@ -633,8 +633,8 @@ public void updateDashMode()
         log.info("New wallet created to replace the wiped locked wallet");
     }
 
-    public void clearDataAndExit() {
-        clearApplicationData();
+    public void resetWalletAndExit() {
+        eraseAndCreateNewWallet();
         log.info("closing app after wallet wipe");
         Process.killProcess(Process.myPid());
         System.exit(1);

--- a/wallet/src/de/schildbach/wallet/WalletApplication.java
+++ b/wallet/src/de/schildbach/wallet/WalletApplication.java
@@ -83,6 +83,7 @@ public class WalletApplication extends Application implements Application.Activi
     private static WalletApplication instance;
     private Configuration config;
     private ActivityManager activityManager;
+    private Activity currentActivity;
 
     private Intent blockchainServiceIntent;
     private Intent blockchainServiceCancelCoinsReceivedIntent;
@@ -112,6 +113,12 @@ public class WalletApplication extends Application implements Application.Activi
     }
 
     @Override
+    protected void attachBaseContext(Context base) {
+        super.attachBaseContext(base);
+        instance = this;
+    }
+
+    @Override
     public void onCreate() {
         //Memory Leak Detection
         if (LeakCanary.isInAnalyzerProcess(this)) {
@@ -119,7 +126,6 @@ public class WalletApplication extends Application implements Application.Activi
             // You should not init your app in this process.
             return;
         }
-        instance = this;
         refWatcher = LeakCanary.install(this);
 
         registerActivityLifecycleCallbacks(this);
@@ -583,6 +589,7 @@ public void updateDashMode()
             lockWalletIfNeeded();
         }
         numStarted++;
+        currentActivity = activity;
     }
 
     @Override
@@ -633,12 +640,7 @@ public void updateDashMode()
         log.info("New wallet created to replace the wiped locked wallet");
     }
 
-    public void resetWalletAndExit() {
-        eraseAndCreateNewWallet();
-        log.info("closing app after wallet wipe");
-        Process.killProcess(Process.myPid());
-        System.exit(1);
-    }
+
 
     public boolean isBackupDisclaimerDismissed() {
         return backupDisclaimerDismissed;
@@ -650,6 +652,14 @@ public void updateDashMode()
 
     public static WalletApplication getInstance() {
         return instance;
+    }
+
+    public void killAllActivities() {
+        if (currentActivity != null) {
+            currentActivity.finishAffinity();
+        } else {
+            System.exit(0);
+        }
     }
 
 }

--- a/wallet/src/de/schildbach/wallet/ui/AbstractWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/AbstractWalletActivity.java
@@ -26,6 +26,7 @@ import org.slf4j.LoggerFactory;
 
 import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet.data.WalletLock;
+import de.schildbach.wallet.ui.preference.PinRetryController;
 import de.schildbach.wallet_test.R;
 
 import android.support.v7.app.AppCompatActivity;
@@ -100,7 +101,9 @@ public abstract class AbstractWalletActivity extends AppCompatActivity implement
     }
 
     private void unlockWallet() {
-        UnlockWalletDialogFragment.show(getFragmentManager());
+        PinRetryController pinRetryController = new PinRetryController(this);
+        if(!pinRetryController.handleLockedForever())
+            UnlockWalletDialogFragment.show(getFragmentManager());
     }
 
     @Override

--- a/wallet/src/de/schildbach/wallet/ui/AbstractWalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/AbstractWalletActivity.java
@@ -51,6 +51,8 @@ public abstract class AbstractWalletActivity extends AppCompatActivity implement
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.LOLLIPOP)
             setTaskDescription(new TaskDescription(null, null, getResources().getColor(R.color.bg_action_bar)));
 
+        PinRetryController.handleLockedForever(this);
+
         WalletLock.getInstance().addListener(this);
         super.onCreate(savedInstanceState);
     }
@@ -101,8 +103,7 @@ public abstract class AbstractWalletActivity extends AppCompatActivity implement
     }
 
     private void unlockWallet() {
-        PinRetryController pinRetryController = new PinRetryController(this);
-        if(!pinRetryController.handleLockedForever())
+        if(!PinRetryController.handleLockedForever(this))
             UnlockWalletDialogFragment.show(getFragmentManager());
     }
 

--- a/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
+++ b/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
@@ -53,6 +53,12 @@ public class PinRetryController {
         return locked;
     }
 
+
+    public boolean isLockedForever() {
+        int failCount = prefs.getStringSet(PREFS_FAILED_PINS, new HashSet<String>()).size();
+        return failCount >= FAIL_LIMIT;
+    }
+
     public void clearPreferences() {
         SharedPreferences.Editor prefsEditor = prefs.edit();
         prefsEditor.remove(PREFS_FAIL_HEIGHT);
@@ -145,6 +151,15 @@ public class PinRetryController {
 
     private void wipeWallet() {
         showResetWalletDialog(true);
+    }
+
+    // returns true if the wallet is wiped
+    public boolean handleLockedForever() {
+        if(isLockedForever()) {
+            wipeWallet();
+            return true;
+        }
+        return false;
     }
 
     public void storeSecureTime(Date date) {

--- a/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
+++ b/wallet/src/de/schildbach/wallet/ui/preference/PinRetryController.java
@@ -141,7 +141,10 @@ public class PinRetryController {
             @Override
             public void onClick(DialogInterface dialog, int which) {
                 clearPreferences();
-                WalletApplication.getInstance().clearDataAndExit();
+                WalletApplication.getInstance().eraseAndCreateNewWallet();
+                if(activity != null)
+                    activity.finish();
+                else Process.killProcess(Process.myPid());
             }
         });
         dialogBuilder.setPositiveButton(android.R.string.no, forceClose ? new DialogInterface.OnClickListener() {


### PR DESCRIPTION
Purpose:
Prevent Brute forcing by adding the code to reset the wallet after the PIN is entered incorrectly 8 times and also to allow for logging to show that the 

In WalletApplication, I removed the delete all files methods and replaced it with:
1.  Create a new wallet (nonencrypted)
2.  Replace current wallet (user forgot their PIN that encrypts it) with new wallet (nonencrypted)

This method will preserve all settings and logs (for diagnosis of problems and so we will know that the user wiped the wallet).

The other code that closes the app remains the same.  The user must restart the app and it will be as if it was a fresh install.  The user will need to enter the mandatory PIN.

The second part of this is to add the code that will wipe the wallet after the PIN is entered incorrectly 8 times.

**Testing:**
Install the app with this PR.
Enter the PIN wrong 4 times to see the dialog that allows reset.
Go to the Settings on the android and set the time ahead to skip waiting between entering incorrect PIN's.
On the 8th attempt, ensure that the app doesn't allow canceling the Reset Dialog.  Ensure that there is not another way to reenter the PIN to keep trying.  The app should require a reset.