### PR TITLE
Added foreground service permission in Manifest

### DIFF
--- a/wallet/AndroidManifest.xml
+++ b/wallet/AndroidManifest.xml
@@ -13,6 +13,7 @@
     <uses-permission android:name="android.permission.NFC" />
     <uses-permission android:name="android.permission.VIBRATE" />
     <uses-permission android:name="android.permission.WAKE_LOCK" />
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <!-- dangerous permissions -->
     <uses-permission android:name="android.permission.CAMERA" /> <!-- group: CAMERA -->


### PR DESCRIPTION
- This is a requirement since Android 9 for apps that execute foreground services.