### PR TITLE
Use $dashjVersion for all modules instead of hard coded version

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,3 +1,7 @@
+ext {
+    dashjVersion = "0.14.7"
+}
+
 buildscript {
     repositories {
         google()

--- a/common/build.gradle
+++ b/common/build.gradle
@@ -31,7 +31,7 @@ dependencies {
     implementation fileTree(dir: 'libs', include: ['*.jar'])
     implementation 'com.android.support:appcompat-v7:28.0.0'
     api 'com.android.support:customtabs:28.0.0'
-    implementation 'org.dashj:dashj-core:0.14.7'
+    implementation "org.dashj:dashj-core:$dashjVersion"
 
     //Retrofit + OkHttp
     api 'com.squareup.okhttp:okhttp:2.7.5'

--- a/sample-integration-android/build.gradle
+++ b/sample-integration-android/build.gradle
@@ -8,7 +8,7 @@ dependencies {
     implementation(project(':integration-android')) {
         exclude(group: 'com.google.android', module: 'android')
     }
-    implementation 'org.dashj:dashj-core:0.14.7'
+    implementation "org.dashj:dashj-core:$dashjVersion"
 }
 
 android {

--- a/uphold-integration/build.gradle
+++ b/uphold-integration/build.gradle
@@ -34,7 +34,7 @@ dependencies {
     androidTestImplementation('com.android.support.test.espresso:espresso-core:3.0.1', {
         exclude group: 'com.android.support', module: 'support-annotations'
     })
-    implementation 'org.dashj:dashj-core:0.14.7'
+    implementation "org.dashj:dashj-core:$dashjVersion"
     implementation 'com.scottyab:secure-preferences-lib:0.1.4'
 
     implementation project(path: ':common')

--- a/wallet/build.gradle
+++ b/wallet/build.gradle
@@ -29,7 +29,7 @@ dependencies {
     implementation "com.android.support:recyclerview-v7:$androidSupportVersion"
     implementation "com.android.support:cardview-v7:$androidSupportVersion"
     implementation "com.android.support:preference-v7:$androidSupportVersion"
-    implementation 'org.dashj:dashj-core:0.14.7'
+    implementation "org.dashj:dashj-core:$dashjVersion"
     implementation 'com.google.protobuf:protobuf-java:2.6.1'
     implementation 'com.google.guava:guava:20.0'
     implementation 'com.google.zxing:core:3.3.0'


### PR DESCRIPTION
This is to have a single place for the DashJ version.