### PR TITLE
Update travis settings and fix licensing issue

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,11 +7,13 @@ env:
     - ANDROID_NDK_HOME=/opt/android-ndk
     - ADB_INSTALL_TIMEOUT=20 # minutes (2 minutes by default)
     - CMAKE_VERSION=cmake-3.6.3
+    - ANDROID_BUILD_TOOLS_VERSION=28.0.2
 
 before_install:
   # Install SDK license so Android Gradle plugin can install deps.
   - mkdir "$ANDROID_HOME/licenses" || true
   - echo "d56f5187479451eabf01fb78af6dfcb131a6481e" > "$ANDROID_HOME/licenses/android-sdk-license"
+  - echo "24333f8a63b6825ea9c5514f83c2829b004d1fee" > "$ANDROID_HOME/licenses/android-sdk-license"
   # Install the rest of tools (e.g., avdmanager).
   - sdkmanager tools
   # Install the system image.
@@ -52,6 +54,7 @@ android:
     - android-15
     - android-25
     - android-21
+    - android-28
     # Support library
     - extra-android-support
     # Latest artifacts in local repository
@@ -60,8 +63,11 @@ android:
     # Specify at least one system image
     # - sys-img-armeabi-v7a-android-$ANDROID_API_LEVEL
 
-    # The BuildTools version used by your project
-    - build-tools-25.0.2
+    #allow licenses
+  licenses:
+    - 'android-sdk-preview-license-+'
+    - 'android-sdk-license-.+'
+    - 'google-gdk-license-.+'
 
 #Notifications
 notifications:
@@ -70,6 +76,6 @@ notifications:
 script:
 - ./gradlew test
 - ./gradlew assemble_testNet3Debug
-- rm -rf .gradle/2.10
+- rm -rf .gradle/4.4
 - ./gradlew assembleProdDebug
 - ./gradlew assembleProdRelease


### PR DESCRIPTION
Changes were made to get the Travis CI tests to pass:
1.  Add a license hash to prevent travis from stalling

Other changes:
1.  Build tools set to 28
2.  Added licenses (though travis is supposed to approve them by default)