### PR TITLE
Handle dust outputs when ensureMinRequiredFee=false

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1382,7 +1382,7 @@ public final class SendCoinsFragment extends Fragment {
 
                 wallet.completeTx(sendRequest);
                 if(checkDust(sendRequest)) {
-                    sendRequest = createSendRequest(finalPaymentIntent, RequestType.INSTANT_SEND_AUTO_LOCK, false, true);
+                    sendRequest = createSendRequest(finalPaymentIntent, RequestType.REGULAR_PAYMENT, false, true);
                     wallet.completeTx(sendRequest);
                 }
                 dryrunSendRequest = sendRequest;


### PR DESCRIPTION
I found a bug with `SendRequest.ensureMinRequiredFee = false` -- it can result in dust for outputs which are rejected by the network.  Therefore, we need to check for dusty outputs after we complete the transaction `wallet.completeTx` with `TransactionOutput.isDust` and if dust is found, then recreate the transaction with `SendRequest.ensureMinRequiredFee = true`

DMD-882