### PR TITLE
Preventing from NPE when the fingerprint error occurred

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/EnableFingerprintDialog.java
+++ b/wallet/src/de/schildbach/wallet/ui/EnableFingerprintDialog.java
@@ -87,6 +87,11 @@ public class EnableFingerprintDialog extends DialogFragment {
         });
         builder.setCancelable(false);
 
+        fingerprintView = view.findViewById(R.id.fingerprint_view);
+        fingerprintView.setVisibility(View.VISIBLE);
+        fingerprintView.hideSeparator();
+        fingerprintView.setText(R.string.touch_fingerprint_to_enable);
+
         FingerprintHelper fingerprintHelper = new FingerprintHelper(getActivity());
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M && fingerprintHelper.init()) {
             fingerprintCancellationSignal = new CancellationSignal();
@@ -118,11 +123,6 @@ public class EnableFingerprintDialog extends DialogFragment {
         } else {
             dismiss();
         }
-
-        fingerprintView = view.findViewById(R.id.fingerprint_view);
-        fingerprintView.setVisibility(View.VISIBLE);
-        fingerprintView.hideSeparator();
-        fingerprintView.setText(R.string.touch_fingerprint_to_enable);
 
         return builder.create();
     }

--- a/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
+++ b/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
@@ -177,11 +177,13 @@ public class FingerprintHelper {
                 FingerprintManagerCompat.CryptoObject crypto = new FingerprintManagerCompat.CryptoObject(cipher);
                 fingerprintManager.authenticate(crypto, 0, cancellationSignal, authListener, null);
             } else {
+                log.warn("User hasn't granted permission to use Fingerprint");
                 authListener.getCallback()
                         .onFailure("User hasn't granted permission to use Fingerprint",
                                 false, false);
             }
         } catch (Throwable t) {
+            log.warn("An error occurred", t);
             authListener.getCallback().onFailure("An error occurred: " + t.getMessage(),
                     false, false);
         }


### PR DESCRIPTION
I'm unable to reproduce this issue but was able to fix it based on static code analysis.
In rare cases calling the {{fingerprintHelper.savePassword}} method can cause the FingerprintHelper.Callback() is fired immediately, therefore the initialization of _fingerprintView_ in } {{EnableFingerprintDialog.onCreateDialog}} had to be performed before calling {{fingerprintHelper.savePassword}}.
Also, I added some additional logs in order to easily identify the cause of {{fingerprintHelper.savePassword}} to fail in the future.