### PR TITLE
DMD-901, 907 - Fix Missing Fiat Values and Duplicated Fiat Values

### DIFF
--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -94,6 +94,6 @@
 	<string name="enable_fingerprint">Enable fingerprint</string>
 	<string name="touch_fingerprint_sensor">Touch the fingerprint sensor.</string>
 	<string name="touch_fingerprint_to_enable">Touch the fingerprint sensor to enable unlocking with fingerprint.</string>
-	<string name="exchange_rate_missing">Cannot get local currency value</string>
+	<string name="exchange_rate_missing">This payment is too old to calculate the fiat value.</string>
 
 </resources>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -94,5 +94,6 @@
 	<string name="enable_fingerprint">Enable fingerprint</string>
 	<string name="touch_fingerprint_sensor">Touch the fingerprint sensor.</string>
 	<string name="touch_fingerprint_to_enable">Touch the fingerprint sensor to enable unlocking with fingerprint.</string>
+	<string name="exchange_rate_missing">Cannot get local currency value</string>
 
 </resources>

--- a/wallet/res/values/strings-extra.xml
+++ b/wallet/res/values/strings-extra.xml
@@ -94,6 +94,6 @@
 	<string name="enable_fingerprint">Enable fingerprint</string>
 	<string name="touch_fingerprint_sensor">Touch the fingerprint sensor.</string>
 	<string name="touch_fingerprint_to_enable">Touch the fingerprint sensor to enable unlocking with fingerprint.</string>
-	<string name="exchange_rate_missing">This payment is too old to calculate the fiat value.</string>
+	<string name="exchange_rate_missing">This payment is too old to get the fiat value.</string>
 
 </resources>

--- a/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
+++ b/wallet/src/de/schildbach/wallet/ui/TransactionsAdapter.java
@@ -43,6 +43,7 @@ import org.dash.wallet.common.ui.DialogBuilder;
 import org.dash.wallet.common.ui.Formats;
 
 import de.schildbach.wallet.Constants;
+import de.schildbach.wallet.WalletApplication;
 import de.schildbach.wallet.data.AddressBookProvider;
 import de.schildbach.wallet.util.CircularProgressView;
 
@@ -514,16 +515,25 @@ public class TransactionsAdapter extends RecyclerView.Adapter<RecyclerView.ViewH
 
             // fiat value
             final ExchangeRate exchangeRate = tx.getExchangeRate();
+            fiatView.setAmount(null);  //clear the exchange rate first
             if (exchangeRate != null) {
                 fiatView.setFormat(Constants.LOCAL_FORMAT.code(0,
                         PREFIX_ALMOST_EQUAL_TO + exchangeRate.fiat.getCurrencyCode() + " "));
                 Coin absCoin = Coin.valueOf(Math.abs(txCache.value.value));
                 fiatView.setAmount(exchangeRate.coinToFiat(absCoin));
+            } else {
+                fiatView.setText(PREFIX_ALMOST_EQUAL_TO + WalletApplication.getInstance().getConfiguration().getExchangeCurrencyCode() + " ----");
             }
 
             // message
             extendMessageView.setVisibility(View.GONE);
             messageView.setSingleLine(false);
+
+            if(exchangeRate == null && itemView.isActivated()) {
+                extendMessageView.setVisibility(View.VISIBLE);
+                messageView.setSingleLine(false);
+                messageView.setText(R.string.exchange_rate_missing);
+            }
 
             if (purpose == Purpose.KEY_ROTATION) {
                 extendMessageView.setVisibility(View.VISIBLE);

--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1125,6 +1125,7 @@ public final class SendCoinsFragment extends Fragment {
 
         sendRequest.memo = paymentIntent.memo;
         sendRequest.exchangeRate = amountCalculatorLink.getExchangeRate();
+        log.info("Using exchange rate: " + sendRequest.exchangeRate.coinToFiat(Coin.COIN).toFriendlyString());
         sendRequest.aesKey = encryptionKey;
 
         new SendCoinsOfflineTask(wallet, backgroundHandler) {

--- a/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SweepWalletFragment.java
@@ -692,6 +692,7 @@ public class SweepWalletFragment extends Fragment {
 		if (currentExchangeRate != null) {
 			sendRequest.exchangeRate = new org.bitcoinj.utils.ExchangeRate(
 					Coin.COIN, currentExchangeRate.getFiat());
+			log.info("Using exchange rate: " + sendRequest.exchangeRate.coinToFiat(Coin.COIN).toFriendlyString());
 		}
 
 		new SendCoinsOfflineTask(walletToSweep, backgroundHandler) {


### PR DESCRIPTION
Address two issues:
1.  missing fiat values:  now we will show fiat values for all incoming transactions (pending) and transactions that are less then 3 hours old that are in blocks.  we will put a message in the transaction if the fiat value cannot be obtained (a received transaction doesn't follow 1)
2.  duplicate values - we will erase the previous value in the view and then in the case of a null exchangeRate, assign a value of "----".