### PR TITLE
[DMD-951] Paper Wallet Sweep Failure Crash

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/ProgressDialogFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/ProgressDialogFragment.java
@@ -39,7 +39,7 @@ public class ProgressDialogFragment extends DialogFragment {
 
     public static void dismissProgress(final FragmentManager fm) {
         final DialogFragment fragment = (DialogFragment) fm.findFragmentByTag(FRAGMENT_TAG);
-        fragment.dismiss();
+        fragment.dismissAllowingStateLoss();
     }
 
     private static ProgressDialogFragment instance(final String message) {


### PR DESCRIPTION
Changing the dismiss() to dismissAllowingStateLoss() when dismissing the ProgressDialogFragment in order to avoid IllegalStateExceptions when the method is called after moving the app to background.