### PR TITLE
[DMD-952] Backup to File Crash after requesting permission (Android 6)

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -148,6 +148,8 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
     private CanAutoLockGuard canAutoLockGuard;
 
+    private boolean showBackupWalletDialog = false;
+
     @Override
     protected void onCreate(final Bundle savedInstanceState) {
         super.onCreate(savedInstanceState);
@@ -300,6 +302,14 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         checkLowStorageAlert();
         detectUserCountry();
+        showBackupWalletDialogIfNeeded();
+    }
+
+    private void showBackupWalletDialogIfNeeded() {
+        if (showBackupWalletDialog) {
+            BackupWalletDialogFragment.show(getSupportFragmentManager());
+            showBackupWalletDialog = false;
+        }
     }
 
     @Override
@@ -486,7 +496,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         if (ContextCompat.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
-            BackupWalletDialogFragment.show(getSupportFragmentManager());
+            showBackupWalletDialog = true;
         else
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                     REQUEST_CODE_BACKUP_WALLET);

--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -352,7 +352,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
                                            final int[] grantResults) {
         if (requestCode == REQUEST_CODE_BACKUP_WALLET) {
             if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED)
-                handleBackupWallet();
+                showBackupWalletDialog = true;
             else
                 showDialog(DIALOG_BACKUP_WALLET_PERMISSION);
         } else if (requestCode == REQUEST_CODE_RESTORE_WALLET) {
@@ -496,7 +496,7 @@ public final class WalletActivity extends AbstractBindServiceActivity
 
         if (ContextCompat.checkSelfPermission(this,
                 Manifest.permission.WRITE_EXTERNAL_STORAGE) == PackageManager.PERMISSION_GRANTED)
-            showBackupWalletDialog = true;
+            BackupWalletDialogFragment.show(getSupportFragmentManager());
         else
             ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.WRITE_EXTERNAL_STORAGE},
                     REQUEST_CODE_BACKUP_WALLET);


### PR DESCRIPTION
Fixed the crash on Android 6 when BackupWalletDialogFragment.show() method is called before WalletActivity.onResume() causing IllegalStateException or RuntimeException to be thrown.