### PR TITLE
DMD-974 Can't change currency without Sim Card

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -1252,11 +1252,13 @@ public final class WalletActivity extends AbstractBindServiceActivity
                     updateCurrencyExchange(networkCountry.toUpperCase());
                 } else {
                     //Couldn't obtain country code - Use Default
-                    config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+                    if(config.getExchangeCurrencyCode() == null)
+                        config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
                 }
             } else {
                 //No cellular network - Wifi Only
-                config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
+                if(config.getExchangeCurrencyCode() == null)
+                    config.setExchangeCurrencyCode(Constants.DEFAULT_EXCHANGE_CURRENCY);
             }
         } catch (Exception e) {
             //fail safe


### PR DESCRIPTION
Set currency to default if no currency is currently set

This allows the exchange rate activity to be used to select a currency
on devices without SIM cards.  Previously, the user selection would
be reset to USD (the default currency).