### PR TITLE
[DMD-959] QR Code | Instant Send Required

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1685,6 +1685,9 @@ public final class SendCoinsFragment extends Fragment {
                 }
                 instantSendInfo.setVisibility(View.VISIBLE);
                 instantXenable.setVisibility(View.VISIBLE);
+                if (paymentIntent.getUseInstantSend()) {
+                    instantXenable.setChecked(true);
+                }
                 break;
             }
             case REGULAR_PAYMENT: {
@@ -1822,6 +1825,8 @@ public final class SendCoinsFragment extends Fragment {
                         directPaymentEnableView.setChecked(bluetoothAdapter != null && bluetoothAdapter.isEnabled());
                     else if (paymentIntent.isHttpPaymentUrl())
                         directPaymentEnableView.setChecked(!Constants.BUG_OPENSSL_HEARTBLEED);
+
+                    instantXenable.setChecked(paymentIntent.getUseInstantSend());
 
                     requestFocusFirst();
                     updateView();


### PR DESCRIPTION
After scanning a QR code which requires IS, the IS upgrade checkbox in Send Screen is checked automatically.