### PR TITLE
[DMD-755] Fix the app shortcuts

### DIFF
--- a/common/src/main/res/values/colors.xml
+++ b/common/src/main/res/values/colors.xml
@@ -36,6 +36,6 @@
     <color name="bg_list">#40ffffff</color>
     <color name="bg_list_selected">#40808090</color>
     <color name="bg_dialog_title">@android:color/transparent</color>
-    <color name="bg_shortcut">#fff5f5f5</color>
+    <color name="bg_shortcut">@color/colorPrimary</color>
 
 </resources>

--- a/wallet/beta/res/xml/shortcuts.xml
+++ b/wallet/beta/res/xml/shortcuts.xml
@@ -7,7 +7,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.SendCoinsQrActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.dash.wallet.beta" />
     </shortcut>
     <shortcut
         android:icon="@drawable/shortcut_send_coins"
@@ -16,7 +16,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.send.SendCoinsActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.dash.wallet.beta" />
     </shortcut>
     <shortcut
         android:icon="@drawable/shortcut_request_coins"
@@ -25,7 +25,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.RequestCoinsActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.dash.wallet.beta" />
     </shortcut>
 
 </shortcuts>

--- a/wallet/res/drawable/shortcut_request_coins.xml
+++ b/wallet/res/drawable/shortcut_request_coins.xml
@@ -15,12 +15,9 @@
         </shape>
     </item>
     <item
+        android:drawable="@drawable/ic_send_flipped_white_24dp"
         android:gravity="center"
         android:height="@dimen/shortcut_icon_size"
-        android:width="@dimen/shortcut_icon_size">
-        <bitmap
-            android:src="@drawable/ic_send_flipped_white_24dp"
-            android:tint="@color/fg_shortcut" />
-    </item>
+        android:width="@dimen/shortcut_icon_size"/>
 
 </layer-list>

--- a/wallet/res/drawable/shortcut_scan_qr.xml
+++ b/wallet/res/drawable/shortcut_scan_qr.xml
@@ -15,13 +15,9 @@
         </shape>
     </item>
     <item
+        android:drawable="@drawable/ic_qrcode"
         android:gravity="center"
         android:height="@dimen/shortcut_icon_size"
-        android:width="@dimen/shortcut_icon_size">
-        >
-        <bitmap
-            android:src="@drawable/ic_photo_camera_white_24dp"
-            android:tint="@color/fg_shortcut" />
-    </item>
+        android:width="@dimen/shortcut_icon_size"/>
 
 </layer-list>

--- a/wallet/res/drawable/shortcut_send_coins.xml
+++ b/wallet/res/drawable/shortcut_send_coins.xml
@@ -15,13 +15,9 @@
         </shape>
     </item>
     <item
+        android:drawable="@drawable/ic_send_white_24dp"
         android:gravity="center"
         android:height="@dimen/shortcut_icon_size"
-        android:width="@dimen/shortcut_icon_size">
-        >
-        <bitmap
-            android:src="@drawable/ic_send_white_24dp"
-            android:tint="@color/fg_shortcut" />
-    </item>
+        android:width="@dimen/shortcut_icon_size"/>
 
 </layer-list>

--- a/wallet/testNet3/res/xml/shortcuts.xml
+++ b/wallet/testNet3/res/xml/shortcuts.xml
@@ -7,7 +7,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.SendCoinsQrActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.darkcoin.wallet_test" />
     </shortcut>
     <shortcut
         android:icon="@drawable/shortcut_send_coins"
@@ -16,7 +16,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.send.SendCoinsActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.darkcoin.wallet_test" />
     </shortcut>
     <shortcut
         android:icon="@drawable/shortcut_request_coins"
@@ -25,7 +25,7 @@
         <intent
             android:action="android.intent.action.VIEW"
             android:targetClass="de.schildbach.wallet.ui.RequestCoinsActivity"
-            android:targetPackage="hashengineering.darkcoin.wallet" />
+            android:targetPackage="hashengineering.darkcoin.wallet_test" />
     </shortcut>
 
 </shortcuts>


### PR DESCRIPTION
Fixed the issue with the app from shortcuts - in never versions of Gradle the shortcut.xml have no access to ${applicationId} variable so it has to be hardcoded for each flavor. Also fixed the shortcuts icons.