### PR TITLE
DMD-1003 Autolock Announcment Dialog Crash - hotfix 1

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
+++ b/wallet/src/de/schildbach/wallet/ui/WalletActivity.java
@@ -379,6 +379,8 @@ public final class WalletActivity extends AbstractBindServiceActivity
                     dialog(WalletActivity.this, null, R.string.button_scan, messageResId, messageArgs);
                 }
             }.parse();
+        } else {
+            super.onActivityResult(requestCode, resultCode, intent);
         }
     }
 


### PR DESCRIPTION
Added missing `super.onActivityResult(requestCode, resultCode, intent)` call to avoid `IllegalStateException `when showing the dialogs after `onSaveInstanceState` and other potential issues with WalletActivity.