### PR TITLE
[DMD-1020] SendCoinsFragment:  Avoid NPE when exchangeRate is null when logging

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
+++ b/wallet/src/de/schildbach/wallet/ui/send/SendCoinsFragment.java
@@ -1048,7 +1048,9 @@ public final class SendCoinsFragment extends Fragment {
 
         sendRequest.memo = paymentIntent.memo;
         sendRequest.exchangeRate = amountCalculatorLink.getExchangeRate();
-        log.info("Using exchange rate: " + sendRequest.exchangeRate.coinToFiat(Coin.COIN).toFriendlyString());
+        log.info("Using exchange rate: " + (sendRequest.exchangeRate != null
+                ? sendRequest.exchangeRate.coinToFiat(Coin.COIN).toFriendlyString() :
+                "not available"));
         sendRequest.aesKey = encryptionKey;
 
         new SendCoinsOfflineTask(wallet, backgroundHandler) {


### PR DESCRIPTION
The app crashes when the user presses send when the exchange rate is invalid (null).