### PR TITLE
FingerprintHelper:  Resolve authentication succeeded crash

### DIFF
--- a/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
+++ b/wallet/src/de/schildbach/wallet/util/FingerprintHelper.java
@@ -431,8 +431,8 @@ public class FingerprintHelper {
         }
 
         public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
-            Cipher cipher = result.getCryptoObject().getCipher();
             try {
+                Cipher cipher = result.getCryptoObject().getCipher();
                 if (encryptPassword(cipher, password)) {
                     log.info("password encrypted successfully");
                     callback.onSuccess("Encrypted");
@@ -456,8 +456,9 @@ public class FingerprintHelper {
         }
 
         public void onAuthenticationSucceeded(FingerprintManagerCompat.AuthenticationResult result) {
-            Cipher cipher = result.getCryptoObject().getCipher();
+
             try {
+                Cipher cipher = result.getCryptoObject().getCipher();
                 String savedPass = decipher(cipher);
                 if (savedPass != null) {
                     log.info("password decrypted successfully");


### PR DESCRIPTION
This may be unnecessary if the cause of this crash is also resolved here:
https://github.com/HashEngineering/dash-wallet/commit/b2cfced46b1afb2072d8bfc94f188bbaf184b7ca

```
java.lang.NullPointerException:  Attempt to invoke virtual method 'javax.crypto.Cipher android.support.v4.hardware.fingerprint.FingerprintManagerCompat$CryptoObject.getCipher()' on a null object reference
  at de.schildbach.wallet.util.FingerprintHelper$FingerprintDecryptPasswordListener.onAuthenticationSucceeded (FingerprintHelper.java:433) 
  at android.support.v4.hardware.fingerprint.FingerprintManagerCompat$1.onAuthenticationSucceeded (FingerprintManagerCompat.java:176)
  at android.hardware.fingerprint.FingerprintManager$MyHandler.sendAuthenticatedSucceeded (Unknown Source:25) 
  at android.hardware.fingerprint.FingerprintManager$MyHandler.handleMessage (Unknown Source:38) 
  at android.os.Handler.dispatchMessage (Unknown Source:21) 
  at android.os.Looper.loop (Unknown Source:152) 
  at android.app.ActivityThread.main (Unknown Source:68) 
  at java.lang.reflect.Method.invoke (Native Method 
  at com.android.internal.os.Zygote$MethodAndArgsCaller.run (Unknown Source:11)
  at com.android.internal.os.ZygoteInit.main (Unknown Source:203)
```