### PR TITLE
SetPinActivity:  Initialize seed after decrypting a backup file

### DIFF
--- a/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
+++ b/wallet/src/de/schildbach/wallet/ui/SetPinActivity.kt
@@ -263,6 +263,8 @@ class SetPinActivity : AppCompatActivity() {
                 }
                 Status.SUCCESS -> {
                     if (state == State.DECRYPTING) {
+                        val walletApplication = application as WalletApplication
+                        seed = walletApplication.wallet.keyChainSeed.mnemonicCode!!
                         setState(State.SET_PIN)
                     } else {
                         viewModel.initWallet()


### PR DESCRIPTION
This resolves the issue of seeing a blank recovery phrase after
restoring from a backup file after installing for the first time.